### PR TITLE
fix(skills): standardize skill structure per authoring guide

### DIFF
--- a/.claude/skills/safe-workflow/SKILL.md
+++ b/.claude/skills/safe-workflow/SKILL.md
@@ -7,7 +7,11 @@ description: SAFe development workflow guidance including branch naming conventi
 
 > **📋 TEMPLATE**: This skill uses `{TICKET_PREFIX}` as a placeholder. Replace with your project's ticket prefix (e.g., `WOR`, `PROJ`, `FEAT`).
 
-## Trigger Conditions
+## Purpose
+
+Enforce SAFe-compliant git workflow with standardized branch naming, commit message format, and rebase-first merge strategy. Ensures linear history and full traceability to Linear tickets.
+
+## When This Skill Applies
 
 Invoke this skill when:
 

--- a/.claude/skills/testing-patterns/SKILL.md
+++ b/.claude/skills/testing-patterns/SKILL.md
@@ -19,6 +19,53 @@ Invoke this skill when:
 - Running test suites
 - Packaging test evidence for Linear
 
+## Critical Rules
+
+### ❌ FORBIDDEN Patterns
+
+```typescript
+// FORBIDDEN: Direct Prisma calls in tests (bypass RLS)
+const user = await prisma.user.findUnique({ where: { user_id } });
+
+// FORBIDDEN: Shared test state (causes flaky tests)
+let sharedUser: User;
+beforeAll(() => { sharedUser = createUser(); });
+
+// FORBIDDEN: Hard-coded IDs (test pollution)
+const userId = "user-123";
+
+// FORBIDDEN: Missing cleanup (leaky tests)
+it("creates user", async () => {
+  await prisma.user.create({ data: userData });
+  // No cleanup!
+});
+```
+
+### ✅ CORRECT Patterns
+
+```typescript
+// CORRECT: Use RLS context helpers
+const user = await withSystemContext(prisma, "test", async (client) => {
+  return client.user.findUnique({ where: { user_id } });
+});
+
+// CORRECT: Isolated test state per test
+beforeEach(() => {
+  const testUser = createTestUser();
+});
+
+// CORRECT: Unique identifiers
+const userId = `user-${crypto.randomUUID()}`;
+const email = `test-${Date.now()}@example.com`;
+
+// CORRECT: Proper cleanup
+afterEach(async () => {
+  await withSystemContext(prisma, "test", async (client) => {
+    await client.user.deleteMany({ where: { email: { contains: "test-" } } });
+  });
+});
+```
+
 ## Test Directory Structure
 
 ```


### PR DESCRIPTION
## Summary

- Added missing **Purpose** section to `safe-workflow` skill
- Renamed "Trigger Conditions" to "When This Skill Applies" for consistency  
- Added **FORBIDDEN/CORRECT patterns** section to `testing-patterns` skill with RLS-aware test examples

These changes ensure all skills pass the quality checklist defined in `docs/guides/SKILL_AUTHORING_GUIDE.md`.

## Test plan

- [ ] Verify `safe-workflow/SKILL.md` has valid YAML frontmatter
- [ ] Verify `safe-workflow/SKILL.md` now includes Purpose section
- [ ] Verify `testing-patterns/SKILL.md` has FORBIDDEN/CORRECT code patterns
- [ ] Confirm skills still appear in Claude Code skill list

🤖 Generated with [Claude Code](https://claude.com/claude-code)