### PR TITLE
feat(commands): add /release command for full version release workflow [WOR-560]

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -12,7 +12,7 @@ These slash commands are part of the **{{PROJECT_NAME}}™** multi-agent harness
 
 The command architecture and workflow methodology are the intellectual property of {{AUTHOR_NAME}} and {{COMPANY_NAME}}.
 
-## Commands Included (23 total)
+## Commands Included (24 total)
 
 ### Workflow Commands
 
@@ -20,6 +20,7 @@ The command architecture and workflow methodology are the intellectual property 
 |---------|---------|
 | `/start-work` | Begin work on Linear ticket |
 | `/pre-pr` | Run validation before PR |
+| `/release` | Full version release (merge, tag, publish, sync, cleanup) |
 | `/end-work` | Complete work session |
 | `/check-workflow` | Check workflow status |
 | `/update-docs` | Update documentation |

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,276 @@
+---
+description: Execute full version release — merge PRs, version bump, tag, GitHub Release, sync branches, cleanup
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob]
+argument-hint: "<version> (e.g., v2.7.0)"
+---
+
+> **📋 TEMPLATE**: This command uses `{{MAIN_BRANCH}}`, `{{TICKET_PREFIX}}`, and `{{GITHUB_ORG}}/{{GITHUB_REPO}}` placeholders. Replace with your project values.
+
+You are executing a full version release. Follow each phase in order. **Do not skip phases.** Report status after each.
+
+## Input
+
+The user provides a version number (e.g., `v2.7.0`). If not provided, determine the next version by:
+
+```bash
+git tag -l 'v*' | sort -V | tail -1
+```
+
+Then bump the minor version (or ask the user for major/minor/patch).
+
+---
+
+## Phase 1: Pre-Release Validation
+
+### 1.1 Verify Clean State
+
+```bash
+git status                    # Must be clean
+git branch --show-current     # Must be on {{MAIN_BRANCH}}
+git fetch origin
+git log --oneline origin/{{MAIN_BRANCH}}..HEAD  # Must be empty (in sync)
+```
+
+**BLOCKER**: Working tree must be clean and branch must be current with remote.
+
+### 1.2 Check Open PRs
+
+```bash
+gh pr list --state open
+```
+
+**Decision point**: If there are open PRs intended for this release, merge them first (Phase 2). If none, skip to Phase 3.
+
+### 1.3 Verify CI Status
+
+For each open PR to merge:
+
+```bash
+gh pr view <NUMBER> --json mergeStateStatus,statusCheckRollup \
+  --jq '{state: .mergeStateStatus, checks: [.statusCheckRollup[] | "\(.name): \(.conclusion // .status)"]}'
+```
+
+**BLOCKER**: All checks must pass. Do not merge PRs with failing required checks.
+
+---
+
+## Phase 2: Merge Open PRs (if any)
+
+### 2.1 Merge in Dependency Order
+
+For each PR (merge in order — base dependencies first):
+
+```bash
+# Squash merge with proper commit message
+gh pr merge <NUMBER> --squash --subject "type(scope): description [{{TICKET_PREFIX}}-XXX]"
+```
+
+### 2.2 Rebase Dependent PRs
+
+After each merge, rebase any remaining PRs that target the same base:
+
+```bash
+git fetch origin
+git checkout <dependent-branch>
+git rebase origin/{{MAIN_BRANCH}}
+git push --force-with-lease origin <dependent-branch>
+```
+
+Wait for CI to re-run before merging the next PR.
+
+### 2.3 Sync Local After All Merges
+
+```bash
+git checkout {{MAIN_BRANCH}}
+git pull origin {{MAIN_BRANCH}}
+```
+
+---
+
+## Phase 3: Version Bump
+
+### 3.1 Find and Update Version References
+
+Search for current version references:
+
+```bash
+# Find version strings in key files
+grep -rn "v[0-9]\+\.[0-9]\+" README.md CLAUDE.md CONTRIBUTING.md --include="*.md" | grep -v node_modules | grep -v releases/ | grep -v whitepapers/
+```
+
+Update **only active version references** (not historical references in changelogs, upgrade guides, or KT docs):
+
+- `README.md` — version badges, "now at **vX.Y**" text, caveats section
+- Any other files with active version references
+
+### 3.2 Commit Version Bump
+
+```bash
+git add -A
+git commit -m "chore(release): bump version references to <VERSION>
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+### 3.3 Push Version Bump
+
+```bash
+git push origin {{MAIN_BRANCH}}
+```
+
+---
+
+## Phase 4: Tag and Release
+
+### 4.1 Generate Release Notes
+
+Gather changes since the last tag:
+
+```bash
+LAST_TAG=$(git tag -l 'v*' | sort -V | tail -1)
+git log --oneline "$LAST_TAG"..HEAD
+```
+
+Group changes by type:
+- **Features** (`feat:`)
+- **Fixes** (`fix:`)
+- **Documentation** (`docs:`)
+- **Chores** (`chore:`)
+
+### 4.2 Create Annotated Tag
+
+```bash
+git tag -a <VERSION> -m "<VERSION> — <SHORT_SUMMARY>
+
+<CATEGORIZED_CHANGES>"
+git push origin <VERSION>
+```
+
+### 4.3 Create GitHub Release
+
+```bash
+gh release create <VERSION> --title "<VERSION> — <SHORT_SUMMARY>" --notes "$(cat <<'EOF'
+## What's New
+
+### Features
+- <list features>
+
+### Fixes
+- <list fixes>
+
+### Documentation
+- <list doc changes>
+
+## Stats
+- **X files changed**, Y insertions, Z deletions
+- **N Linear tickets** closed
+- Fully backward-compatible with <PREVIOUS_VERSION>
+
+## Upgrade
+<brief upgrade instructions or "No breaking changes.">
+EOF
+)"
+```
+
+---
+
+## Phase 5: Branch Sync
+
+### 5.1 Sync All Long-Lived Branches
+
+If the repository has multiple long-lived branches (e.g., `main` and `template`, or `main` and `dev`), sync them:
+
+```bash
+# Sync secondary branches to match primary
+git push origin {{MAIN_BRANCH}}:<SECONDARY_BRANCH>
+```
+
+Verify sync:
+
+```bash
+git log --oneline origin/{{MAIN_BRANCH}}..origin/<SECONDARY_BRANCH>  # Should be empty
+git log --oneline origin/<SECONDARY_BRANCH>..origin/{{MAIN_BRANCH}}  # Should be empty
+```
+
+### 5.2 Verify All Tags Pushed
+
+```bash
+git tag -l 'v*' | sort -V | tail -5
+gh api repos/{{GITHUB_ORG}}/{{GITHUB_REPO}}/tags --jq '.[0:5] | .[].name'
+```
+
+---
+
+## Phase 6: Cleanup
+
+### 6.1 Delete Merged PR Branches
+
+```bash
+# List remote branches that are not main/dev/template
+gh api repos/{{GITHUB_ORG}}/{{GITHUB_REPO}}/branches --jq '.[].name' | grep -v '^main$\|^dev$\|^template$'
+```
+
+For each stale branch from a merged PR:
+
+```bash
+gh api -X DELETE repos/{{GITHUB_ORG}}/{{GITHUB_REPO}}/git/refs/heads/<BRANCH_NAME>
+```
+
+### 6.2 Clean Local
+
+```bash
+# Delete local branches that were merged
+git branch --merged {{MAIN_BRANCH}} | grep -v '^\*\|{{MAIN_BRANCH}}' | xargs -r git branch -d
+
+# Prune stale remote tracking refs
+git fetch --prune origin
+
+# Garbage collect
+git gc --prune=now
+```
+
+### 6.3 Final Verification
+
+```bash
+echo "=== Local ===" && git branch -v
+echo "=== Remote ===" && gh api repos/{{GITHUB_ORG}}/{{GITHUB_REPO}}/branches --jq '.[].name'
+echo "=== Tags ===" && git tag -l 'v*' | sort -V | tail -5
+echo "=== Release ===" && gh release view <VERSION> --json tagName,publishedAt,isDraft --jq '.'
+echo "=== Open PRs ===" && gh pr list --state open
+```
+
+---
+
+## Output Format
+
+Report final release status:
+
+- ✅ PRs merged: (list with numbers)
+- ✅ Version bumped: `<OLD>` → `<NEW>`
+- ✅ Tag created: `<VERSION>`
+- ✅ GitHub Release published: (URL)
+- ✅ Branches synced: (list)
+- ✅ Stale branches deleted: (count)
+- ✅ Local cleaned and synced
+
+Or flag blockers:
+
+- ❌ BLOCKER: (description and recommended action)
+
+## Success Criteria
+
+- Tag exists locally and on remote
+- GitHub Release is published (not draft)
+- All long-lived branches are in sync
+- No stale merged-PR branches remain
+- Local working tree is clean on {{MAIN_BRANCH}}
+- Zero open PRs intended for this release
+
+## Customization Guide
+
+| Placeholder | Description | Example |
+|-------------|-------------|---------|
+| `{{MAIN_BRANCH}}` | Primary branch name | `main`, `template` |
+| `{{TICKET_PREFIX}}` | Linear/Jira ticket prefix | `WOR`, `SCA`, `PROJ` |
+| `{{GITHUB_ORG}}` | GitHub organization | `bybren-llc` |
+| `{{GITHUB_REPO}}` | GitHub repository name | `safe-agentic-workflow` |

--- a/.gemini/commands/workflow/release.toml
+++ b/.gemini/commands/workflow/release.toml
@@ -1,0 +1,77 @@
+description = "Execute full version release — merge PRs, version bump, tag, GitHub Release, sync branches, cleanup"
+
+prompt = """
+# Release Command
+
+You are executing a full version release. Follow each phase in order. Do not skip phases. Report status after each.
+
+## Input
+
+The user provides a version number (e.g., v2.7.0). If not provided, determine the next version:
+
+!{git tag -l 'v*' | sort -V | tail -1}
+
+Then bump the minor version (or ask the user for major/minor/patch).
+
+## Phase 1: Pre-Release Validation
+
+### 1.1 Verify Clean State
+- Working tree must be clean
+- Must be on {{MAIN_BRANCH}}
+- Must be in sync with remote
+
+### 1.2 Check Open PRs
+- List all open PRs
+- If any are intended for this release, merge them first (Phase 2)
+
+### 1.3 Verify CI Status
+- All checks must pass on PRs to merge
+- BLOCKER: Do not merge PRs with failing required checks
+
+## Phase 2: Merge Open PRs (if any)
+
+- Squash merge each PR with proper commit message: type(scope): description [{{TICKET_PREFIX}}-XXX]
+- Rebase dependent PRs after each merge
+- Wait for CI to re-run before merging next
+- Sync local after all merges
+
+## Phase 3: Version Bump
+
+- Find and update version references in README.md, badges, caveats section
+- Only update active references (not changelogs, upgrade guides, KT docs)
+- Commit: chore(release): bump version references to <VERSION>
+- Push to {{MAIN_BRANCH}}
+
+## Phase 4: Tag and Release
+
+- Generate categorized release notes from git log since last tag
+- Create annotated git tag
+- Push tag
+- Create GitHub Release with release notes
+
+## Phase 5: Branch Sync
+
+- Sync all long-lived branches (e.g., main ↔ template, main ↔ dev)
+- Verify all tags pushed to remote
+
+## Phase 6: Cleanup
+
+- Delete merged PR branches from remote
+- Delete merged local branches
+- Prune stale remote tracking refs
+- Run git gc
+- Final verification: branches, tags, release, open PRs
+
+## Output Format
+
+Report final release status:
+- PRs merged (list with numbers)
+- Version bumped (old → new)
+- Tag created
+- GitHub Release published (URL)
+- Branches synced (list)
+- Stale branches deleted (count)
+- Local cleaned and synced
+
+Or flag blockers with recommended action.
+"""

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,6 +26,6 @@ abstract: >-
   A production-tested Claude Code harness for teams that want structured AI
   workflows. Built on SAFe methodology, adapted for multi-agent teams. Based
   on 5 months of production experience (169 issues, 9 cycles, 2,193 commits).
-  Includes 18 model-invoked skills, 23 slash commands, 11 SAFe agent profiles,
+  Includes 18 model-invoked skills, 24 slash commands, 11 SAFe agent profiles,
   and a three-layer architecture implementing patterns from Anthropic's
   engineering research.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <img src="https://img.shields.io/badge/skills-18%20model--invoked-purple?style=flat-square" alt="Skills">
   </a>
   <a href=".claude/commands/">
-    <img src="https://img.shields.io/badge/commands-23%20workflows-orange?style=flat-square" alt="Commands">
+    <img src="https://img.shields.io/badge/commands-24%20workflows-orange?style=flat-square" alt="Commands">
   </a>
   <img src="https://img.shields.io/badge/template-ready-brightgreen?style=flat-square" alt="Template Ready">
 </p>
@@ -41,7 +41,7 @@ Works for any team with repeatable processes: Software, Marketing, Research, Leg
 Includes:
 
 - **18 Model-Invoked Skills** - Domain expertise that loads automatically (Skills 2.0 frontmatter)
-- **23 Slash Commands** - Workflow automation for common tasks
+- **24 Slash Commands** - Workflow automation for common tasks
 - **11 SAFe Agent Profiles** - Specialized roles with clear boundaries
 - **Three-Layer Architecture** - Hooks → Commands → Skills
 - **Agent Teams** - Multi-agent orchestration with SAFe quality gates (experimental)
@@ -129,7 +129,7 @@ export GEMINI_API_KEY="your-api-key"
 
 ### Full Command Reference
 
-**Workflow** (7): `/start-work`, `/pre-pr`, `/end-work`, `/check-workflow`, `/update-docs`, `/retro`, `/sync-linear`
+**Workflow** (8): `/start-work`, `/pre-pr`, `/release`, `/end-work`, `/check-workflow`, `/update-docs`, `/retro`, `/sync-linear`
 
 **Local Operations** (3): `/local-sync`, `/local-deploy`, `/quick-fix`
 
@@ -1190,14 +1190,14 @@ See project documentation for honest assessment of limitations.
 
 ```text
 .claude/                 # Claude Code harness configuration
-├── commands/            # 23 slash commands for workflow automation
+├── commands/            # 24 slash commands for workflow automation
 ├── skills/              # 18 model-invoked skills for domain expertise
 ├── agents/              # 11 SAFe agent profiles
 ├── team-config.json     # Agent Teams settings (optional, experimental)
 └── SETUP.md             # Installation and customization guide
 
 .gemini/                 # Gemini CLI harness configuration
-├── commands/            # 29 TOML commands (namespaced: /workflow:*, /local:*, /remote:*, /media:*)
+├── commands/            # 30 TOML commands (namespaced: /workflow:*, /local:*, /remote:*, /media:*)
 ├── skills/              # 17 model-invoked skills (team-coordination is Claude-only)
 ├── settings.json        # Configuration (model, hooks, policy, security)
 ├── GEMINI.md            # System instructions

--- a/docs/whitepapers/README.md
+++ b/docs/whitepapers/README.md
@@ -13,7 +13,7 @@ The complete technical documentation of the three-layer harness architecture:
 - Background and motivation
 - Three-layer architecture (Hooks → Commands → Skills)
 - All 18 skills with implementation details
-- All 23 slash commands organized by category
+- All 24 slash commands organized by category
 - Phase 0-3 completion history
 - SAFe role expansion vision
 - Operational SOPs reference


### PR DESCRIPTION
## Summary

Adds a `/release` slash command that automates the full version release workflow (6 phases). Also adds the Gemini equivalent.

**Linear Ticket**: https://linear.app/cheddarfox/issue/WOR-560

## Changes

- **`.claude/commands/release.md`** — 6-phase release command (pre-validate → merge PRs → version bump → tag & release → branch sync → cleanup)
- **`.gemini/commands/workflow/release.toml`** — Gemini CLI equivalent
- **Badge/count updates** — 23→24 commands (Claude), 29→30 (Gemini) across README, commands README, whitepapers README, CITATION.cff

## Testing

```bash
# Command files exist
ls -la .claude/commands/release.md .gemini/commands/workflow/release.toml

# Badge count updated
grep "commands-24" README.md

# Commands README updated
grep "24 total" .claude/commands/README.md
grep "/release" .claude/commands/README.md

# No stale "23 commands" references
grep -rn "23 slash commands\|23 Slash Commands" --include="*.md" --include="*.cff" . | grep -v whitepapers/CLAUDE-CODE
```

## Pre-merge Checklist

- [x] Rebased on latest template
- [x] Uses `{{PLACEHOLDER}}` tokens (no hardcoded values)
- [x] Skills 2.0 frontmatter (`description`, `allowed-tools`, `argument-hint`)
- [x] Linear ticket referenced in commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)