### PR TITLE
fix(skills): add allowed-tools to 9 remaining skills [WOR-561]

### DIFF
--- a/.claude/skills/api-patterns/SKILL.md
+++ b/.claude/skills/api-patterns/SKILL.md
@@ -2,6 +2,7 @@
 name: api-patterns
 description: API route implementation patterns with RLS, Zod validation, and error handling. Use when creating API routes, implementing endpoints, or adding server-side validation.
 user-invocable: false
+allowed-tools: Read, Grep, Glob
 ---
 
 # API Patterns Skill

--- a/.claude/skills/deployment-sop/SKILL.md
+++ b/.claude/skills/deployment-sop/SKILL.md
@@ -3,6 +3,7 @@ name: deployment-sop
 description: Deployment workflows, pre-deploy validation, and smoke testing patterns. Use when deploying to staging or production, running smoke tests, or validating deployments.
 disable-model-invocation: true
 argument-hint: "[environment]"
+allowed-tools: Read, Bash, Grep, Glob
 ---
 
 # Deployment SOP Skill

--- a/.claude/skills/frontend-patterns/SKILL.md
+++ b/.claude/skills/frontend-patterns/SKILL.md
@@ -2,6 +2,7 @@
 name: frontend-patterns
 description: Frontend patterns for Next.js App Router, Clerk auth, shadcn/Radix UI, and PostHog analytics. Use when building UI components, creating pages, implementing auth flows, or adding analytics events. Ensures consistent UX patterns and accessibility standards.
 user-invocable: false
+allowed-tools: Read, Grep, Glob
 ---
 
 # Frontend Patterns Skill

--- a/.claude/skills/migration-patterns/SKILL.md
+++ b/.claude/skills/migration-patterns/SKILL.md
@@ -2,6 +2,7 @@
 name: migration-patterns
 description: Database migration creation with mandatory RLS policies and ARCHitect approval workflow. Use when creating migrations, adding tables with RLS, or updating Prisma schema.
 disable-model-invocation: true
+allowed-tools: Read, Bash, Grep, Glob
 ---
 
 # Migration Patterns Skill

--- a/.claude/skills/release-patterns/SKILL.md
+++ b/.claude/skills/release-patterns/SKILL.md
@@ -3,6 +3,7 @@ name: release-patterns
 description: PR creation, CI/CD validation, and release coordination patterns. Use when creating pull requests, running pre-PR validation, checking CI status, or coordinating merges.
 disable-model-invocation: true
 argument-hint: "[ticket-id]"
+allowed-tools: Read, Bash, Grep, Glob
 ---
 
 # Release Patterns Skill

--- a/.claude/skills/rls-patterns/SKILL.md
+++ b/.claude/skills/rls-patterns/SKILL.md
@@ -2,6 +2,7 @@
 name: rls-patterns
 description: Row Level Security patterns for database operations. Use when writing Prisma/database code, creating API routes that access data, or implementing webhooks. Enforces withUserContext, withAdminContext, or withSystemContext helpers. NEVER use direct prisma calls.
 user-invocable: false
+allowed-tools: Read, Grep, Glob
 ---
 
 # RLS Patterns Skill

--- a/.claude/skills/safe-workflow/SKILL.md
+++ b/.claude/skills/safe-workflow/SKILL.md
@@ -2,6 +2,7 @@
 name: safe-workflow
 description: SAFe development workflow guidance including branch naming conventions, commit message format, rebase-first workflow, and CI validation. Use when starting work on a Linear ticket, preparing commits, creating branches, writing PR descriptions, or asking about contribution guidelines.
 user-invocable: false
+allowed-tools: Read, Grep, Glob
 ---
 
 # SAFe Workflow Skill

--- a/.claude/skills/spec-creation/SKILL.md
+++ b/.claude/skills/spec-creation/SKILL.md
@@ -3,6 +3,7 @@ name: spec-creation
 description: Spec creation with pattern references, acceptance criteria, and demo scripts. Use when creating implementation specs, defining acceptance criteria, or breaking down user stories.
 context: fork
 argument-hint: "[ticket-id]"
+allowed-tools: Read, Write, Grep, Glob
 ---
 
 # Spec Creation Skill

--- a/.claude/skills/stripe-patterns/SKILL.md
+++ b/.claude/skills/stripe-patterns/SKILL.md
@@ -2,6 +2,7 @@
 name: stripe-patterns
 description: Stripe payment integration patterns. Use when implementing payment flows, handling webhooks, or working with subscriptions. Routes to existing patterns and provides evidence templates for payment testing.
 user-invocable: false
+allowed-tools: Read, Grep, Glob
 ---
 
 # Stripe Patterns Skill


### PR DESCRIPTION
## Summary

Completes the Skills 2.0 modernization by adding `allowed-tools` frontmatter to all 9 remaining skills. All 18 skills now have full Skills 2.0 compliance.

**Linear Ticket**: https://linear.app/cheddarfox/issue/WOR-561

## Changes

9 files changed, 9 insertions — exactly 1 line added per skill:

### Background Knowledge (`user-invocable: false`) — read-only
| Skill | `allowed-tools` |
|-------|----------------|
| `api-patterns` | `Read, Grep, Glob` |
| `frontend-patterns` | `Read, Grep, Glob` |
| `rls-patterns` | `Read, Grep, Glob` |
| `safe-workflow` | `Read, Grep, Glob` |
| `stripe-patterns` | `Read, Grep, Glob` |

### Manual-Only (`disable-model-invocation: true`) — with Bash
| Skill | `allowed-tools` |
|-------|----------------|
| `deployment-sop` | `Read, Bash, Grep, Glob` |
| `migration-patterns` | `Read, Bash, Grep, Glob` |
| `release-patterns` | `Read, Bash, Grep, Glob` |

### Fork (`context: fork`) — with Write
| Skill | `allowed-tools` |
|-------|----------------|
| `spec-creation` | `Read, Write, Grep, Glob` |

## Design Principle

**Least privilege**: Background knowledge skills are read-only (no Bash/Write/Edit). Manual-only skills get Bash for execution. Fork skills get Write for file creation. No skill gets tools it doesn't need.

## Testing

All 6 QA tests passed:

```
QA Test 1: All 18 skills have allowed-tools — 18/18 PASS
QA Test 2: Background knowledge read-only — 5/5 PASS
QA Test 3: Manual-only skills have Bash — 3/3 PASS
QA Test 4: Fork skills have write capability — 3/3 PASS
QA Test 5: Invocation control matrix complete — 13/13 PASS
QA Test 6: No unintended changes — 9 files, +9 lines, -0 lines
```

## Pre-merge Checklist

- [x] Rebased on latest template
- [x] 9 files, 9 insertions, 0 deletions
- [x] No existing frontmatter fields disturbed
- [x] Principle of least privilege applied
- [x] Linear ticket referenced in commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)