### PR TITLE
docs: update README badges for v2.9.0 [SAW-32]

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,27 @@
 **A Production-Tested Three-Layer Architecture for Coordinated AI Teams**
 
 <p align="center">
+  <img src="https://img.shields.io/badge/version-v2.9.0-blue?style=flat-square" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="License">
+  <img src="https://img.shields.io/badge/template-ready-brightgreen?style=flat-square" alt="Template Ready">
+  <img src="https://img.shields.io/badge/tests-382%2F382-brightgreen?style=flat-square" alt="Tests">
+  <a href="https://deepwiki.com/bybren-llc/safe-agentic-workflow">
+    <img src="https://img.shields.io/badge/DeepWiki-bybren--llc%2Fsafe--agentic--workflow-blue?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBhdGggZD0iTTQgMTloMTYiLz48cGF0aCBkPSJNNCAxNWg4Ii8+PHBhdGggZD0iTTQgMTFoMTIiLz48cGF0aCBkPSJNNCA3aDE2Ii8+PC9zdmc+" alt="DeepWiki">
+  </a>
+</p>
+<p align="center">
+  <a href=".claude/agents/">
+    <img src="https://img.shields.io/badge/agents-11%20SAFe%20roles-red?style=flat-square" alt="Agents">
+  </a>
   <a href=".claude/skills/">
     <img src="https://img.shields.io/badge/skills-18%20model--invoked-purple?style=flat-square" alt="Skills">
   </a>
   <a href=".claude/commands/">
     <img src="https://img.shields.io/badge/commands-24%20workflows-orange?style=flat-square" alt="Commands">
   </a>
-  <img src="https://img.shields.io/badge/template-ready-brightgreen?style=flat-square" alt="Template Ready">
+  <a href=".cursor/rules/">
+    <img src="https://img.shields.io/badge/cursor%20rules-16-00D084?style=flat-square" alt="Cursor Rules">
+  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Post-release badge update for v2.9.0.

**New badges**: version (v2.9.0), tests (382/382), agents (11 SAFe roles), Cursor rules (16), DeepWiki link.

**Reorganized**: Two rows — status badges on top, capability badges below.

## Test Plan
- [x] Badge markdown syntax verified
- [x] DeepWiki URL points to correct repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)