### PR TITLE
feat(schema): manifest v1.1 — sync_scope + root-relative paths [SAW-33]

### DIFF
--- a/.claude/.harness-manifest.yml
+++ b/.claude/.harness-manifest.yml
@@ -7,8 +7,8 @@
 # perform intelligent syncing: applying substitutions, respecting renames,
 # and never overwriting protected files.
 #
-# Location: .claude/.harness-manifest.yml (current), migrating to repo root in SAW-34
-# Scope: .claude/ only (current sync engine). sync_scope enables multi-domain in SAW-35
+# Location: .claude/.harness-manifest.yml
+# Scope: .claude/ only (current sync engine). sync_scope defined for future multi-domain
 # Docs: docs/HARNESS_MANIFEST_SCHEMA.md
 #
 # If this file is absent, the sync script falls back to legacy behavior

--- a/.harness-manifest.schema.json
+++ b/.harness-manifest.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/bybren-llc/safe-agentic-workflow/blob/main/.harness-manifest.schema.json",
   "title": "Harness Manifest",
-  "description": "Schema for .harness-manifest.yml — declares how a downstream fork customizes the SAFe Agentic Workflow harness. In v1.1+, all paths are repo-root-relative. In v1.0, paths are relative to .claude/ and normalized during load.",
+  "description": "Schema for .harness-manifest.yml — declares how a downstream fork customizes the SAFe Agentic Workflow harness. Current location: .claude/.harness-manifest.yml (migrating to repo root in SAW-34). In v1.1+, all paths in renames/protected/replaced are repo-root-relative. In v1.0, paths are .claude/-relative and normalized during load.",
   "type": "object",
   "required": ["manifest_version", "identity"],
   "additionalProperties": false,
@@ -231,7 +231,7 @@
         },
         "backup": {
           "type": "boolean",
-          "description": "Create a timestamped backup of synced domains before each sync. Backups stored at .harness-backup/ (repo root).",
+          "description": "Create a timestamped backup before each sync. Current: .claude/.harness-backup/. Planned (SAW-34): .harness-backup/ at repo root.",
           "default": true
         },
         "conflict_strategy": {

--- a/.harness-manifest.schema.json
+++ b/.harness-manifest.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/ByBren-LLC/safe-agentic-workflow/blob/template/.harness-manifest.schema.json",
+  "$id": "https://github.com/bybren-llc/safe-agentic-workflow/blob/main/.harness-manifest.schema.json",
   "title": "Harness Manifest",
-  "description": "Schema for .harness-manifest.yml — declares how a downstream fork customizes the SAFe Agentic Workflow harness. All paths are relative to .claude/ (v2.7.0 scope).",
+  "description": "Schema for .harness-manifest.yml — declares how a downstream fork customizes the SAFe Agentic Workflow harness. In v1.1+, all paths are repo-root-relative. In v1.0, paths are relative to .claude/ and normalized during load.",
   "type": "object",
   "required": ["manifest_version", "identity"],
   "additionalProperties": false,
@@ -11,7 +11,7 @@
       "type": "string",
       "description": "Schema version for forward compatibility. Must be a semver-compatible string (e.g., '1.0').",
       "pattern": "^[0-9]+\\.[0-9]+$",
-      "examples": ["1.0"]
+      "examples": ["1.0", "1.1"]
     },
     "identity": {
       "type": "object",
@@ -165,41 +165,41 @@
     },
     "renames": {
       "type": "object",
-      "description": "Map of upstream path (relative to .claude/) to local path (relative to .claude/). Use trailing '/' to indicate directory renames. File renames take precedence over directory renames when both match.",
+      "description": "Map of upstream path to local path. In v1.1+, paths are repo-root-relative (e.g., '.claude/agents/fe-developer.md'). In v1.0, paths are relative to .claude/ and normalized during load. Use trailing '/' for directory renames. File renames take precedence over directory renames.",
       "additionalProperties": {
         "type": "string",
         "minLength": 1
       },
       "propertyNames": {
-        "description": "Upstream path relative to .claude/. Must not start with / or contain ..",
+        "description": "Upstream path. Must not start with / or contain ..",
         "pattern": "^[^/]"
       },
       "examples": [
         {
-          "agents/fe-developer.md": "agents/ui-engineer.md",
-          "skills/stripe-patterns/": "skills/payment-patterns/"
+          ".claude/agents/fe-developer.md": ".claude/agents/ui-engineer.md",
+          ".gemini/skills/stripe-patterns/": ".gemini/skills/payment-patterns/"
         }
       ]
     },
     "protected": {
       "type": "array",
-      "description": "Glob patterns (relative to .claude/) that the sync script must NEVER overwrite. These files are completely skipped during sync.",
+      "description": "Glob patterns that the sync script must NEVER overwrite. In v1.1+, patterns are repo-root-relative (e.g., '.claude/hooks-config.json'). In v1.0, patterns are relative to .claude/ and normalized during load.",
       "items": {
         "type": "string",
-        "description": "Glob pattern relative to .claude/. Supports *, **, and ? wildcards.",
+        "description": "Glob pattern. Supports *, **, and ? wildcards.",
         "minLength": 1
       },
       "uniqueItems": true,
       "examples": [
-        ["hooks-config.json", "settings.local.json", "agents/custom-*.md"]
+        [".claude/hooks-config.json", ".claude/settings.local.json", ".codex/config.toml"]
       ]
     },
     "replaced": {
       "type": "array",
-      "description": "Paths (relative to .claude/) that the fork has completely rewritten. These are not overwritten during sync, but the sync script warns if the upstream version has changed since last sync.",
+      "description": "Paths that the fork has completely rewritten. In v1.1+, paths are repo-root-relative. In v1.0, paths are relative to .claude/ and normalized during load. These are not overwritten during sync, but the script warns if upstream changed.",
       "items": {
         "type": "string",
-        "description": "File path relative to .claude/.",
+        "description": "File path (repo-root-relative in v1.1+).",
         "minLength": 1
       },
       "uniqueItems": true,
@@ -212,6 +212,18 @@
       "description": "Sync behavior preferences. All fields have sensible defaults.",
       "additionalProperties": false,
       "properties": {
+        "sync_scope": {
+          "type": "array",
+          "description": "Repo-root-relative directories to sync from upstream. Added in v1.1. Defaults to [\".claude/\"] for v1.0 backward compatibility. Allowed domains: provider (.claude/, .gemini/, .codex/, .cursor/), shared (.agents/, dark-factory/). Release domains (docs/, scripts/, patterns_library/) are not yet supported and will be rejected.",
+          "items": {
+            "type": "string",
+            "enum": [".claude/", ".gemini/", ".codex/", ".cursor/", ".agents/", "dark-factory/"],
+            "description": "Sync domain directory (must be from the allowed domain list)."
+          },
+          "uniqueItems": true,
+          "default": [".claude/"],
+          "minItems": 1
+        },
         "auto_substitute": {
           "type": "boolean",
           "description": "Automatically apply substitutions from identity/substitutions to incoming upstream files during sync.",
@@ -219,7 +231,7 @@
         },
         "backup": {
           "type": "boolean",
-          "description": "Create a timestamped backup of .claude/ before each sync.",
+          "description": "Create a timestamped backup of synced domains before each sync. Backups stored at .harness-backup/ (repo root).",
           "default": true
         },
         "conflict_strategy": {

--- a/.harness-manifest.schema.json
+++ b/.harness-manifest.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/bybren-llc/safe-agentic-workflow/blob/main/.harness-manifest.schema.json",
   "title": "Harness Manifest",
-  "description": "Schema for .harness-manifest.yml — declares how a downstream fork customizes the SAFe Agentic Workflow harness. Current location: .claude/.harness-manifest.yml (migrating to repo root in SAW-34). In v1.1+, all paths in renames/protected/replaced are repo-root-relative. In v1.0, paths are .claude/-relative and normalized during load.",
+  "description": "Schema for .claude/.harness-manifest.yml — declares how a downstream fork customizes the SAFe Agentic Workflow harness. In v1.1+, all paths in renames/protected/replaced are repo-root-relative. In v1.0, paths are .claude/-relative and normalized during load.",
   "type": "object",
   "required": ["manifest_version", "identity"],
   "additionalProperties": false,

--- a/.harness-manifest.schema.json
+++ b/.harness-manifest.schema.json
@@ -171,7 +171,7 @@
         "minLength": 1
       },
       "propertyNames": {
-        "description": "Upstream path. Must not start with / or contain ..",
+        "description": "Upstream path (repo-root-relative). Must not start with / and must not contain path traversal (..). Runtime enforcement by sync script preflight check provides additional safety.",
         "pattern": "^[^/]"
       },
       "examples": [
@@ -204,7 +204,7 @@
       },
       "uniqueItems": true,
       "examples": [
-        ["agents/system-architect.md", "AGENT_OUTPUT_GUIDE.md"]
+        [".claude/agents/system-architect.md", ".claude/AGENT_OUTPUT_GUIDE.md"]
       ]
     },
     "sync": {

--- a/.harness-manifest.yml
+++ b/.harness-manifest.yml
@@ -7,8 +7,8 @@
 # perform intelligent syncing: applying substitutions, respecting renames,
 # and never overwriting protected files.
 #
-# Location: .harness-manifest.yml (repository root)
-# Scope: Multi-domain (v1.1 — sync_scope defines which directories sync)
+# Location: .claude/.harness-manifest.yml (current), migrating to repo root in SAW-34
+# Scope: .claude/ only (current sync engine). sync_scope enables multi-domain in SAW-35
 # Docs: docs/HARNESS_MANIFEST_SCHEMA.md
 #
 # If this file is absent, the sync script falls back to legacy behavior
@@ -144,7 +144,11 @@ replaced: []
 # -----------------------------------------------------------------------------
 # Tuning knobs for sync behavior. All have sensible defaults.
 sync:
-  # Sync scope: which directories to sync from upstream (v1.1+).
+  # Sync scope: which directories to sync from upstream (v1.1 schema).
+  # NOTE: Multi-domain sync is defined in schema v1.1 but not yet implemented
+  # in the sync engine. Until SAW-35 lands, only .claude/ is actually synced
+  # regardless of this setting. This field is forward-declared so manifests
+  # are ready when the engine ships.
   # Allowed domains:
   #   Provider: .claude/, .gemini/, .codex/, .cursor/
   #   Shared:   .agents/, dark-factory/
@@ -164,9 +168,10 @@ sync:
   # Set to false to sync raw upstream files without token replacement.
   auto_substitute: true
 
-  # Create a timestamped backup of synced domains before each sync.
+  # Create a timestamped backup before each sync.
   # Default: true
-  # Backups are stored in .harness-backup/<domain>/<timestamp>/ (repo root)
+  # Current: backups at .claude/.harness-backup/<timestamp>/
+  # Planned (SAW-34): migrate to .harness-backup/<domain>/<timestamp>/ at repo root
   backup: true
 
   # Strategy for resolving conflicts when both upstream and local

--- a/.harness-manifest.yml
+++ b/.harness-manifest.yml
@@ -1,5 +1,5 @@
 # =============================================================================
-# Harness Manifest Schema - v1.0.0
+# Harness Manifest Schema - v1.1.0
 # =============================================================================
 #
 # This file declares how a downstream fork has customized the upstream
@@ -8,7 +8,7 @@
 # and never overwriting protected files.
 #
 # Location: .harness-manifest.yml (repository root)
-# Scope: .claude/ directory only (v2.7.0)
+# Scope: Multi-domain (v1.1 — sync_scope defines which directories sync)
 # Docs: docs/HARNESS_MANIFEST_SCHEMA.md
 #
 # If this file is absent, the sync script falls back to legacy behavior
@@ -20,7 +20,7 @@
 # -----------------------------------------------------------------------------
 # Allows the sync script to handle older manifest formats gracefully.
 # Bump only when the schema itself changes in a backward-incompatible way.
-manifest_version: "1.0"
+manifest_version: "1.1"
 
 # -----------------------------------------------------------------------------
 # Identity (REQUIRED)
@@ -78,21 +78,20 @@ substitutions: {}
 # -----------------------------------------------------------------------------
 # Renames (OPTIONAL)
 # -----------------------------------------------------------------------------
-# Map of upstream relative path -> local relative path.
-# All paths are relative to .claude/ (v2.7.0 scope).
+# Map of upstream path -> local path (repo-root-relative in v1.1+).
 #
 # Use this when a fork has renamed files or directories from their upstream
 # names. The sync script maps incoming upstream paths to local paths.
 #
 # File rename example:
-#   "agents/fe-developer.md": "agents/ui-engineer.md"
+#   ".claude/agents/fe-developer.md": ".claude/agents/ui-engineer.md"
 #
 # Directory rename example (trailing / is REQUIRED for directories):
-#   "skills/stripe-patterns/": "skills/payment-patterns/"
+#   ".gemini/skills/stripe-patterns/": ".gemini/skills/payment-patterns/"
 #
 # Rules:
-# - Source (left) is the upstream path relative to .claude/
-# - Target (right) is the local path relative to .claude/
+# - Source (left) is the upstream path (repo-root-relative)
+# - Target (right) is the local path (repo-root-relative)
 # - Trailing / distinguishes directory renames from file renames
 # - Directory renames apply recursively to all contained files
 # - If a file matches both a directory rename and a file rename,
@@ -102,7 +101,7 @@ renames: {}
 # -----------------------------------------------------------------------------
 # Protected (OPTIONAL)
 # -----------------------------------------------------------------------------
-# List of glob patterns (relative to .claude/) that the sync script must
+# Glob patterns (repo-root-relative in v1.1+) that the sync script must
 # NEVER overwrite. Protected files are completely skipped during sync.
 #
 # Use this for files with project-specific configuration that would break
@@ -112,15 +111,15 @@ renames: {}
 #
 # Example:
 #   protected:
-#     - "hooks-config.json"
-#     - "settings.local.json"
-#     - "agents/custom-*.md"
+#     - ".claude/hooks-config.json"
+#     - ".claude/settings.local.json"
+#     - ".codex/config.toml"
 protected: []
 
 # -----------------------------------------------------------------------------
 # Replaced (OPTIONAL)
 # -----------------------------------------------------------------------------
-# List of paths (relative to .claude/) that the fork has completely
+# Paths (repo-root-relative in v1.1+) that the fork has completely
 # rewritten. Unlike protected files, these still have an upstream
 # counterpart — but the fork's version is authoritative.
 #
@@ -136,8 +135,8 @@ protected: []
 #
 # Example:
 #   replaced:
-#     - "agents/system-architect.md"
-#     - "AGENT_OUTPUT_GUIDE.md"
+#     - ".claude/agents/system-architect.md"
+#     - ".claude/AGENT_OUTPUT_GUIDE.md"
 replaced: []
 
 # -----------------------------------------------------------------------------
@@ -145,15 +144,29 @@ replaced: []
 # -----------------------------------------------------------------------------
 # Tuning knobs for sync behavior. All have sensible defaults.
 sync:
+  # Sync scope: which directories to sync from upstream (v1.1+).
+  # Allowed domains:
+  #   Provider: .claude/, .gemini/, .codex/, .cursor/
+  #   Shared:   .agents/, dark-factory/
+  # Release domains (docs/, scripts/, patterns_library/) deferred to future version.
+  # Default: [".claude/"]
+  sync_scope:
+    - ".claude/"
+    - ".gemini/"
+    - ".codex/"
+    - ".cursor/"
+    - ".agents/"
+    - "dark-factory/"
+
   # Automatically apply substitutions from the identity/substitutions
   # sections to incoming upstream files during sync.
   # Default: true
   # Set to false to sync raw upstream files without token replacement.
   auto_substitute: true
 
-  # Create a timestamped backup of .claude/ before each sync.
+  # Create a timestamped backup of synced domains before each sync.
   # Default: true
-  # Backups are stored in .claude/.harness-backup/<timestamp>/
+  # Backups are stored in .harness-backup/<domain>/<timestamp>/ (repo root)
   backup: true
 
   # Strategy for resolving conflicts when both upstream and local

--- a/docs/HARNESS_MANIFEST_SCHEMA.md
+++ b/docs/HARNESS_MANIFEST_SCHEMA.md
@@ -27,7 +27,7 @@ upstream SAFe Agentic Workflow harness. When the sync script
 
 ### Backward Compatibility
 
-If `.harness-manifest.yml` is absent, the sync script falls back to legacy
+If `.claude/.harness-manifest.yml` is absent, the sync script falls back to legacy
 behavior: file-level copy with `.sync-exclude` pattern matching and no
 automatic substitution. This ensures existing forks continue to work
 without modification.
@@ -39,23 +39,27 @@ without modification.
 After running `scripts/setup-template.sh`, generate your manifest:
 
 ```bash
-# The setup wizard will create .harness-manifest.yml automatically
-# (planned for v2.7.0 setup-template.sh integration)
+# Auto-generate from project state (recommended):
+./scripts/sync-claude-harness.sh init
+./scripts/sync-claude-harness.sh manifest init
 
-# For existing forks, create manually:
-cp examples/manifests/rendertrust.harness-manifest.yml .harness-manifest.yml
+# Or create manually from an example:
+cp examples/manifests/rendertrust.harness-manifest.yml .claude/.harness-manifest.yml
 # Then edit identity values and customization sections
 ```
 
 Validate your manifest:
 
 ```bash
-# Using yq + jsonschema (Python)
-pip install check-jsonschema
-check-jsonschema --schemafile .harness-manifest.schema.json .harness-manifest.yml
+# Using the sync script (recommended):
+./scripts/sync-claude-harness.sh manifest validate
 
-# Using ajv (Node.js)
-npx ajv-cli validate -s .harness-manifest.schema.json -d .harness-manifest.yml
+# Using jsonschema (Python):
+pip install check-jsonschema
+check-jsonschema --schemafile .harness-manifest.schema.json .claude/.harness-manifest.yml
+
+# Using ajv (Node.js):
+npx ajv-cli validate -s .harness-manifest.schema.json -d .claude/.harness-manifest.yml
 ```
 
 ---
@@ -403,7 +407,7 @@ migrate to the manifest format:
 ### Step 1: Create the manifest
 
 ```bash
-cp examples/manifests/rendertrust.harness-manifest.yml .harness-manifest.yml
+cp examples/manifests/rendertrust.harness-manifest.yml .claude/.harness-manifest.yml
 ```
 
 ### Step 2: Fill in identity values
@@ -413,14 +417,14 @@ manifest's `identity` section.
 
 ### Step 3: Convert .sync-exclude to protected
 
-Each line in `.sync-exclude` becomes an entry in `protected`:
+Each line in `.claude/.sync-exclude` becomes an entry in `protected`:
 
 ```yaml
-# Before (.sync-exclude):
+# Before (.claude/.sync-exclude):
 # hooks-config.json
 # settings.local.json
 
-# After (.harness-manifest.yml):
+# After (.claude/.harness-manifest.yml):
 protected:
   - "hooks-config.json"
   - "settings.local.json"
@@ -435,7 +439,7 @@ shows more than 50% of lines changed, it is a replaced file.
 ### Step 5: Validate
 
 ```bash
-check-jsonschema --schemafile .harness-manifest.schema.json .harness-manifest.yml
+./scripts/sync-claude-harness.sh manifest validate
 ```
 
 ### Step 6: Keep .sync-exclude (transitional)
@@ -454,17 +458,20 @@ The `.harness-manifest.schema.json` file provides a JSON Schema (2020-12)
 for validating manifest files. Use any YAML-aware JSON Schema validator:
 
 ```bash
-# Python (check-jsonschema)
-pip install check-jsonschema
-check-jsonschema --schemafile .harness-manifest.schema.json .harness-manifest.yml
+# Using the sync script (recommended):
+./scripts/sync-claude-harness.sh manifest validate
 
-# Node.js (ajv-cli)
-npx ajv-cli validate -s .harness-manifest.schema.json -d .harness-manifest.yml
+# Python (check-jsonschema):
+pip install check-jsonschema
+check-jsonschema --schemafile .harness-manifest.schema.json .claude/.harness-manifest.yml
+
+# Node.js (ajv-cli):
+npx ajv-cli validate -s .harness-manifest.schema.json -d .claude/.harness-manifest.yml
 
 # VS Code / IDE
 # Add to .vscode/settings.json:
 # "yaml.schemas": {
-#   ".harness-manifest.schema.json": ".harness-manifest.yml"
+#   ".harness-manifest.schema.json": ".claude/.harness-manifest.yml"
 # }
 ```
 

--- a/docs/HARNESS_MANIFEST_SCHEMA.md
+++ b/docs/HARNESS_MANIFEST_SCHEMA.md
@@ -1,16 +1,18 @@
 # Harness Manifest Schema Reference
 
 **Schema version**: 1.1
-**File**: `.harness-manifest.yml` (repository root)
+**File**: `.claude/.harness-manifest.yml` (current) — migrating to repository root in SAW-34
 **JSON Schema**: `.harness-manifest.schema.json`
-**Scope**: Multi-domain (v1.1 — provider, shared, and future release domains)
+**Scope**: `.claude/` only (current sync engine) — multi-domain sync engine shipping in SAW-35
 
 ### What's New in v1.1
 
-- **`sync_scope`**: Array of directories to sync from upstream (default: `[".claude/"]`)
-- **Root-relative paths**: All paths in `renames`, `protected`, `replaced` are now repo-root-relative
+- **`sync_scope`**: Array of directories to sync from upstream (default: `[".claude/"]`) — schema-defined, engine implementation in SAW-35
+- **Root-relative paths**: All paths in `renames`, `protected`, `replaced` are now repo-root-relative in the schema
 - **Domain tiers**: Provider (`.claude/`, `.gemini/`, `.codex/`, `.cursor/`), Shared (`.agents/`, `dark-factory/`), Release (`docs/`, `scripts/` — deferred)
 - **Backward compat**: v1.0 manifests work unchanged — paths without scope prefix are normalized by prepending `.claude/` during load
+
+> **Implementation status**: SAW-33 defines the v1.1 schema. The sync engine still operates on `.claude/` only until SAW-34 (metadata migration) and SAW-35 (multi-domain engine) are merged. `sync_scope` is forward-declared so manifests are ready when the engine ships.
 
 ## Overview
 
@@ -334,12 +336,15 @@ be rejected if listed. These will be added in a future version with separate gat
 
 **Default behavior**: If `sync_scope` is absent (v1.0 manifests), defaults to `[".claude/"]`.
 
-**Manifest is authoritative**: The sync script will only sync domains listed in `sync_scope`.
-Auto-detection is used only during `manifest init` to propose an initial scope. After the
-manifest is written, it drives all sync behavior deterministically.
+**Planned behavior (SAW-35)**: The sync script will only sync domains listed in `sync_scope`.
+Auto-detection will be used only during `manifest init` to propose an initial scope. After
+the manifest is written, it will drive all sync behavior deterministically.
 
-**Important**: `sync` requires a manifest. Without a manifest, sync will fail (even with
-`--scope`), except for `--dry-run` which is allowed for inspection.
+**Planned (SAW-35)**: `sync` will require a manifest. Without a manifest, sync will fail
+(even with `--scope`), except for `--dry-run` which will be allowed for inspection.
+
+> **Current behavior**: The sync engine ignores `sync_scope` and syncs `.claude/` only.
+> Multi-domain sync ships in SAW-35.
 
 #### `auto_substitute` (default: `true`)
 
@@ -352,8 +357,9 @@ substitution separately (e.g., via a post-sync hook).
 
 #### `backup` (default: `true`)
 
-When `true`, the sync script creates a timestamped backup of synced domains
-before each sync. Backups are stored at `.harness-backup/<domain>/<timestamp>/` (repo root).
+When `true`, the sync script creates a timestamped backup before each sync.
+Current: backups at `.claude/.harness-backup/<timestamp>/`. Planned (SAW-34): migrate to
+`.harness-backup/<domain>/<timestamp>/` at repo root.
 
 The three most recent backups are retained; older ones are pruned
 automatically.

--- a/docs/HARNESS_MANIFEST_SCHEMA.md
+++ b/docs/HARNESS_MANIFEST_SCHEMA.md
@@ -1,9 +1,16 @@
 # Harness Manifest Schema Reference
 
-**Schema version**: 1.0
+**Schema version**: 1.1
 **File**: `.harness-manifest.yml` (repository root)
 **JSON Schema**: `.harness-manifest.schema.json`
-**Scope**: `.claude/` directory only (v2.7.0)
+**Scope**: Multi-domain (v1.1 — provider, shared, and future release domains)
+
+### What's New in v1.1
+
+- **`sync_scope`**: Array of directories to sync from upstream (default: `[".claude/"]`)
+- **Root-relative paths**: All paths in `renames`, `protected`, `replaced` are now repo-root-relative
+- **Domain tiers**: Provider (`.claude/`, `.gemini/`, `.codex/`, `.cursor/`), Shared (`.agents/`, `dark-factory/`), Release (`docs/`, `scripts/` — deferred)
+- **Backward compat**: v1.0 manifests work unchanged — paths without scope prefix are normalized by prepending `.claude/` during load
 
 ## Overview
 

--- a/docs/HARNESS_MANIFEST_SCHEMA.md
+++ b/docs/HARNESS_MANIFEST_SCHEMA.md
@@ -63,7 +63,7 @@ npx ajv-cli validate -s .harness-manifest.schema.json -d .harness-manifest.yml
 ### `manifest_version` (REQUIRED)
 
 ```yaml
-manifest_version: "1.0"
+manifest_version: "1.1"
 ```
 
 Schema version string in `MAJOR.MINOR` format. The sync script uses this to
@@ -72,7 +72,8 @@ changes in a backward-incompatible way.
 
 | Version | Description |
 |---------|-------------|
-| `1.0`   | Initial schema (v2.7.0). Covers identity, substitutions, renames, protected, replaced, sync. |
+| `1.0`   | Initial schema (v2.7.0). `.claude/`-only scope. Paths relative to `.claude/`. |
+| `1.1`   | Multi-domain sync (v2.10.0). Adds `sync_scope`, root-relative paths. Backward compat with v1.0. |
 
 ---
 
@@ -179,14 +180,15 @@ with the corresponding value before writing to disk.
 
 ```yaml
 renames:
-  # File rename
-  "agents/fe-developer.md": "agents/ui-engineer.md"
+  # File rename (repo-root-relative in v1.1+)
+  ".claude/agents/fe-developer.md": ".claude/agents/ui-engineer.md"
 
   # Directory rename (trailing / required)
-  "skills/stripe-patterns/": "skills/payment-patterns/"
+  ".gemini/skills/stripe-patterns/": ".gemini/skills/payment-patterns/"
 ```
 
-Map of upstream path to local path. All paths are relative to `.claude/`.
+Map of upstream path to local path. In v1.1+, all paths are repo-root-relative.
+In v1.0, paths are relative to `.claude/` and normalized during load by prepending `.claude/`.
 
 **File renames:**
 
@@ -195,7 +197,7 @@ writes it to the target path instead.
 
 ```
 Upstream: .claude/agents/fe-developer.md
-Manifest: "agents/fe-developer.md" -> "agents/ui-engineer.md"
+Manifest: ".claude/agents/fe-developer.md" -> ".claude/agents/ui-engineer.md"
 Result:   .claude/agents/ui-engineer.md (with substitutions applied)
 ```
 
@@ -206,9 +208,9 @@ directory are mapped to the target directory, preserving subdirectory
 structure.
 
 ```
-Upstream: .claude/skills/stripe-patterns/webhook-handler.md
-Manifest: "skills/stripe-patterns/" -> "skills/payment-patterns/"
-Result:   .claude/skills/payment-patterns/webhook-handler.md
+Upstream: .gemini/skills/stripe-patterns/webhook-handler.md
+Manifest: ".gemini/skills/stripe-patterns/" -> ".gemini/skills/payment-patterns/"
+Result:   .gemini/skills/payment-patterns/webhook-handler.md
 ```
 
 **Precedence rules:**
@@ -223,12 +225,13 @@ Result:   .claude/skills/payment-patterns/webhook-handler.md
 
 ```yaml
 protected:
-  - "hooks-config.json"
-  - "settings.local.json"
-  - "agents/custom-*.md"
+  - ".claude/hooks-config.json"
+  - ".claude/settings.local.json"
+  - ".codex/config.toml"
+  - ".cursor/rules/custom-*.mdc"
 ```
 
-List of glob patterns (relative to `.claude/`) that the sync script must
+List of glob patterns (repo-root-relative in v1.1+) that the sync script must
 **never overwrite**. Protected files are completely skipped during sync.
 
 **Use cases:**
@@ -258,20 +261,20 @@ mapping). If a file has been renamed, use the local name in `protected`.
 
 ```yaml
 replaced:
-  - "agents/system-architect.md"
-  - "AGENT_OUTPUT_GUIDE.md"
+  - ".claude/agents/system-architect.md"
+  - ".claude/AGENT_OUTPUT_GUIDE.md"
 ```
 
-List of paths (relative to `.claude/`) that the fork has completely
+List of paths (repo-root-relative in v1.1+) that the fork has completely
 rewritten. These files exist in both upstream and the fork, but the fork's
 version is authoritative.
 
 **Behavior during sync:**
 
 1. The file is **not** overwritten
-2. The sync script logs: `Skipped (replaced): agents/system-architect.md`
+2. The sync script logs: `Skipped (replaced): .claude/agents/system-architect.md`
 3. If the upstream version has changed since last sync, the script emits a
-   warning: `WARNING: Upstream changed replaced file: agents/system-architect.md`
+   warning: `WARNING: Upstream changed replaced file: .claude/agents/system-architect.md`
 4. The maintainer can then manually review the upstream diff and decide
    whether to incorporate changes
 
@@ -289,6 +292,13 @@ version is authoritative.
 
 ```yaml
 sync:
+  sync_scope:
+    - ".claude/"
+    - ".gemini/"
+    - ".codex/"
+    - ".cursor/"
+    - ".agents/"
+    - "dark-factory/"
   auto_substitute: true
   backup: true
   conflict_strategy: "prompt"
@@ -307,6 +317,30 @@ sync:
 
 Tuning knobs for sync behavior. All fields have sensible defaults.
 
+#### `sync_scope` (default: `[".claude/"]`) — NEW in v1.1
+
+Array of repo-root-relative directories to sync from upstream. Only domains in this list
+are synced; all others are skipped.
+
+**Allowed domains (v2.10.0):**
+
+| Tier | Domains | Description |
+|------|---------|-------------|
+| Provider | `.claude/`, `.gemini/`, `.codex/`, `.cursor/` | IDE-specific harness configs |
+| Shared | `.agents/`, `dark-factory/` | Cross-provider shared resources |
+
+Release domains (`docs/`, `scripts/`, `patterns_library/`) are not yet supported and will
+be rejected if listed. These will be added in a future version with separate gating.
+
+**Default behavior**: If `sync_scope` is absent (v1.0 manifests), defaults to `[".claude/"]`.
+
+**Manifest is authoritative**: The sync script will only sync domains listed in `sync_scope`.
+Auto-detection is used only during `manifest init` to propose an initial scope. After the
+manifest is written, it drives all sync behavior deterministically.
+
+**Important**: `sync` requires a manifest. Without a manifest, sync will fail (even with
+`--scope`), except for `--dry-run` which is allowed for inspection.
+
 #### `auto_substitute` (default: `true`)
 
 When `true`, the sync script automatically replaces `{{TOKEN}}` placeholders
@@ -318,8 +352,8 @@ substitution separately (e.g., via a post-sync hook).
 
 #### `backup` (default: `true`)
 
-When `true`, the sync script creates a timestamped backup of `.claude/`
-before each sync. Backups are stored at `.claude/.harness-backup/<timestamp>/`.
+When `true`, the sync script creates a timestamped backup of synced domains
+before each sync. Backups are stored at `.harness-backup/<domain>/<timestamp>/` (repo root).
 
 The three most recent backups are retained; older ones are pruned
 automatically.
@@ -435,7 +469,7 @@ The sync script performs runtime validation beyond what JSON Schema catches:
 - Rename targets do not collide (two sources mapping to the same target)
 - Protected patterns do not overlap with replaced paths
 - Identity values that are required for substitution are present
-- Paths do not escape `.claude/` scope (no `../` traversal)
+- Paths do not escape allowed sync domains (no `../` traversal — enforced at runtime by preflight check)
 
 ---
 
@@ -463,9 +497,10 @@ The sync script performs runtime validation beyond what JSON Schema catches:
 - Keeping them separate avoids redundancy: identity is always present,
   substitutions are only needed for overrides
 
-### Why paths relative to `.claude/`?
+### Why root-relative paths in v1.1?
 
-- v2.7.0 scope is `.claude/` only; this avoids scope creep
-- When future versions expand scope, `manifest_version` can introduce
-  a new path resolution mode
-- Relative paths prevent portability issues across machines
+- v1.0 used `.claude/`-relative paths because scope was `.claude/` only
+- v1.1 introduces multi-domain sync (`sync_scope`), so paths need a consistent root
+- Root-relative paths are unambiguous: `.claude/agents/bsa.md` vs `.gemini/skills/safe-workflow/SKILL.md`
+- Backward compat: v1.0 manifests have bare paths normalized by prepending `.claude/` during load
+- Path traversal (`../`) is rejected at runtime by the sync script's preflight check

--- a/docs/HARNESS_MANIFEST_SCHEMA.md
+++ b/docs/HARNESS_MANIFEST_SCHEMA.md
@@ -1,7 +1,7 @@
 # Harness Manifest Schema Reference
 
 **Schema version**: 1.1
-**File**: `.claude/.harness-manifest.yml` (current) — migrating to repository root in SAW-34
+**File**: `.claude/.harness-manifest.yml`
 **JSON Schema**: `.harness-manifest.schema.json`
 **Scope**: `.claude/` only (current sync engine) — multi-domain sync engine shipping in SAW-35
 


### PR DESCRIPTION
## Summary

Schema v1.1 for multi-domain sync support.

- **Linear**: [SAW-33](https://linear.app/cheddarfox/issue/SAW-33)
- **Parent**: [SAW-11](https://linear.app/cheddarfox/issue/SAW-11) — Full-harness sync scope

### Changes

**`.harness-manifest.schema.json`**:
- Added `sync_scope` array to `sync` section (default: `[".claude/"]`)
- Hardcoded allowed domain enum: `.claude/`, `.gemini/`, `.codex/`, `.cursor/`, `.agents/`, `dark-factory/`
- Updated path descriptions: root-relative in v1.1, `.claude/`-relative in v1.0
- Updated examples to use root-relative paths
- Fixed repo URL in `$id`

**`.harness-manifest.yml`**:
- Bumped to v1.1
- Added `sync_scope` with all 6 domains
- Updated all comments to reference root-relative paths

**`docs/HARNESS_MANIFEST_SCHEMA.md`**:
- Updated version and scope header
- Added "What's New in v1.1" section

## Test Plan
- [x] JSON schema is valid JSON
- [x] YAML manifest is valid YAML
- [x] v1.0 backward compat rule documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)