### PR TITLE
chore(release): v2.10.0 docs, version bump, and citations [SAW-38]

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -237,6 +237,21 @@ codex --model o3
 2. Check that each skill has a `SKILL.md` with valid YAML frontmatter
 3. Ensure the `name` and `description` fields are present in frontmatter
 
+## Upstream Sync
+
+This directory can be synced from the upstream SAFe Agentic Workflow harness
+using the multi-domain sync engine (v2.10.0+). Add `".codex/"` to your
+manifest's `sync_scope` to include it in automated syncs:
+
+```yaml
+sync:
+  sync_scope:
+    - ".claude/"
+    - ".codex/"
+```
+
+See [Harness Sync Guide](../docs/HARNESS_SYNC_GUIDE.md) for details.
+
 ## License
 
 MIT License - See [LICENSE](../LICENSE) for details.

--- a/.gemini/README.md
+++ b/.gemini/README.md
@@ -600,6 +600,21 @@ This `.gemini/` directory works alongside `.claude/` for teams using both tools:
 
 Both tools can coexist in the same repository.
 
+## Upstream Sync
+
+This directory can be synced from the upstream SAFe Agentic Workflow harness
+using the multi-domain sync engine (v2.10.0+). Add `".gemini/"` to your
+manifest's `sync_scope` to include it in automated syncs:
+
+```yaml
+sync:
+  sync_scope:
+    - ".claude/"
+    - ".gemini/"
+```
+
+See [Harness Sync Guide](../docs/HARNESS_SYNC_GUIDE.md) for details.
+
 ## License
 
 MIT License - See [LICENSE](../LICENSE) for details.

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,11 +1,11 @@
-@techreport{wtfb2025safe,
-  title={Claude Code Harness for Multi-Agent Team Workflows},
-  author={Graham, J. Scott and {WTFB Development Team}},
+@techreport{saw2026safe,
+  title={SAW — SAFe Agentic Workflow},
+  author={Graham, J. Scott and {ByBren, LLC}},
   year={2026},
   month={March},
-  institution={ByBren LLC},
+  institution={ByBren, LLC},
   type={White Paper},
-  version={2.9.0},
+  version={2.10.0},
   url={https://github.com/bybren-llc/safe-agentic-workflow},
-  note={Production-tested harness: 5 months, 169 issues, 2193 commits. Implements Anthropic's agent patterns.}
+  note={Multi-provider AI agent harness for structured team workflows. Implements Anthropic's agent patterns.}
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,11 +4,11 @@ authors:
   - family-names: "Graham"
     given-names: "J. Scott"
     alias: "cheddarfox"
-    email: "scott@wordstofilmby.com"
-  - name: "WTFB Development Team"
-title: "Claude Code Harness for Multi-Agent Team Workflows"
-version: 2.9.0
-date-released: 2026-03-18
+    email: "scott@cheddarfox.com"
+  - name: "ByBren, LLC"
+title: "SAW — SAFe Agentic Workflow"
+version: 2.10.0
+date-released: 2026-03-19
 url: "https://github.com/bybren-llc/safe-agentic-workflow"
 keywords:
   - multi-agent

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **A Production-Tested Three-Layer Architecture for Coordinated AI Teams**
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-v2.9.0-blue?style=flat-square" alt="Version">
+  <img src="https://img.shields.io/badge/version-v2.10.0-blue?style=flat-square" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="License">
   <img src="https://img.shields.io/badge/template-ready-brightgreen?style=flat-square" alt="Template Ready">
   <img src="https://img.shields.io/badge/tests-382%2F382-brightgreen?style=flat-square" alt="Tests">
@@ -142,29 +142,33 @@ cursor /your-project
 
 Already using the harness and a new version is out? You have two paths:
 
-**Automated** (`.claude/` directory only):
+**Automated** (multi-domain, manifest-based):
 ```bash
 # Initialize sync metadata (first time only)
 ./scripts/sync-claude-harness.sh init
 ./scripts/sync-claude-harness.sh manifest init --yes
 
-# Preview and apply
-./scripts/sync-claude-harness.sh sync --version v2.9.0 --dry-run
-./scripts/sync-claude-harness.sh sync --version v2.9.0
+# Preview and apply (syncs all domains in your manifest's sync_scope)
+./scripts/sync-claude-harness.sh sync --version v2.10.0 --dry-run
+./scripts/sync-claude-harness.sh sync --version v2.10.0
+
+# Sync specific domains only
+./scripts/sync-claude-harness.sh sync --version v2.10.0 --scope .claude,.gemini
 ```
 
 **Manual** (full release, all providers):
 ```bash
 git remote add harness https://github.com/bybren-llc/safe-agentic-workflow.git
 git fetch harness main --tags
-git diff v2.8.1..v2.9.0 --stat              # See what changed
-git checkout harness/main -- .codex/agents/  # Cherry-pick what you need
-bash scripts/setup-template.sh               # Re-apply your placeholders
+git diff v2.9.0..v2.10.0 --stat              # See what changed
+git checkout harness/main -- .codex/agents/   # Cherry-pick what you need
+bash scripts/setup-template.sh                # Re-apply your placeholders
 ```
 
-> The sync script protects your customizations via a manifest. It won't overwrite
-> files you've marked as protected. See the [Harness Sync Guide](docs/HARNESS_SYNC_GUIDE.md)
-> for the full reference and [Upgrade Guide](docs/releases/v2.9.0-UPGRADE.md) for rollback options.
+> The sync script protects your customizations via a manifest (required since v2.10.0).
+> It won't overwrite files you've marked as protected. See the
+> [Harness Sync Guide](docs/HARNESS_SYNC_GUIDE.md) for the full reference and
+> [Upgrade Guide](docs/releases/v2.10.0-UPGRADE.md) for rollback options.
 
 ---
 

--- a/docs/HARNESS_MANIFEST_SCHEMA.md
+++ b/docs/HARNESS_MANIFEST_SCHEMA.md
@@ -1,18 +1,16 @@
 # Harness Manifest Schema Reference
 
 **Schema version**: 1.1
-**File**: `.claude/.harness-manifest.yml`
+**File**: `.harness-manifest.yml` (repo root)
 **JSON Schema**: `.harness-manifest.schema.json`
-**Scope**: `.claude/` only (current sync engine) — multi-domain sync engine shipping in SAW-35
+**Scope**: Multi-domain (v2.10.0) — syncs any domain listed in `sync_scope`
 
 ### What's New in v1.1
 
-- **`sync_scope`**: Array of directories to sync from upstream (default: `[".claude/"]`) — schema-defined, engine implementation in SAW-35
+- **`sync_scope`**: Array of directories to sync from upstream (default: `[".claude/"]`)
 - **Root-relative paths**: All paths in `renames`, `protected`, `replaced` are now repo-root-relative in the schema
 - **Domain tiers**: Provider (`.claude/`, `.gemini/`, `.codex/`, `.cursor/`), Shared (`.agents/`, `dark-factory/`), Release (`docs/`, `scripts/` — deferred)
 - **Backward compat**: v1.0 manifests work unchanged — paths without scope prefix are normalized by prepending `.claude/` during load
-
-> **Implementation status**: SAW-33 defines the v1.1 schema. The sync engine still operates on `.claude/` only until SAW-34 (metadata migration) and SAW-35 (multi-domain engine) are merged. `sync_scope` is forward-declared so manifests are ready when the engine ships.
 
 ## Overview
 
@@ -27,10 +25,9 @@ upstream SAFe Agentic Workflow harness. When the sync script
 
 ### Backward Compatibility
 
-If `.claude/.harness-manifest.yml` is absent, the sync script falls back to legacy
-behavior: file-level copy with `.sync-exclude` pattern matching and no
-automatic substitution. This ensures existing forks continue to work
-without modification.
+If `.harness-manifest.yml` is absent, the sync script fails with an error
+(except when using `--dry-run`, which is allowed for inspection). Use
+`./scripts/sync-claude-harness.sh manifest init` to generate a manifest.
 
 ---
 
@@ -44,7 +41,7 @@ After running `scripts/setup-template.sh`, generate your manifest:
 ./scripts/sync-claude-harness.sh manifest init
 
 # Or create manually from an example:
-cp examples/manifests/rendertrust.harness-manifest.yml .claude/.harness-manifest.yml
+cp examples/manifests/rendertrust.harness-manifest.yml .harness-manifest.yml
 # Then edit identity values and customization sections
 ```
 
@@ -56,10 +53,10 @@ Validate your manifest:
 
 # Using jsonschema (Python):
 pip install check-jsonschema
-check-jsonschema --schemafile .harness-manifest.schema.json .claude/.harness-manifest.yml
+check-jsonschema --schemafile .harness-manifest.schema.json .harness-manifest.yml
 
 # Using ajv (Node.js):
-npx ajv-cli validate -s .harness-manifest.schema.json -d .claude/.harness-manifest.yml
+npx ajv-cli validate -s .harness-manifest.schema.json -d .harness-manifest.yml
 ```
 
 ---
@@ -340,15 +337,12 @@ be rejected if listed. These will be added in a future version with separate gat
 
 **Default behavior**: If `sync_scope` is absent (v1.0 manifests), defaults to `[".claude/"]`.
 
-**Planned behavior (SAW-35)**: The sync script will only sync domains listed in `sync_scope`.
-Auto-detection will be used only during `manifest init` to propose an initial scope. After
-the manifest is written, it will drive all sync behavior deterministically.
+The sync script only syncs domains listed in `sync_scope`. Auto-detection is used only
+during `manifest init` to propose an initial scope. After the manifest is written, it
+drives all sync behavior deterministically.
 
-**Planned (SAW-35)**: `sync` will require a manifest. Without a manifest, sync will fail
-(even with `--scope`), except for `--dry-run` which will be allowed for inspection.
-
-> **Current behavior**: The sync engine ignores `sync_scope` and syncs `.claude/` only.
-> Multi-domain sync ships in SAW-35.
+A manifest is required for sync. Without a manifest, sync fails (even with `--scope`),
+except for `--dry-run` which is allowed for inspection.
 
 #### `auto_substitute` (default: `true`)
 
@@ -362,8 +356,7 @@ substitution separately (e.g., via a post-sync hook).
 #### `backup` (default: `true`)
 
 When `true`, the sync script creates a timestamped backup before each sync.
-Current: backups at `.claude/.harness-backup/<timestamp>/`. Planned (SAW-34): migrate to
-`.harness-backup/<domain>/<timestamp>/` at repo root.
+Backups are stored at `.harness-backup/<domain>/<timestamp>/` at the repo root.
 
 The three most recent backups are retained; older ones are pruned
 automatically.
@@ -407,7 +400,7 @@ migrate to the manifest format:
 ### Step 1: Create the manifest
 
 ```bash
-cp examples/manifests/rendertrust.harness-manifest.yml .claude/.harness-manifest.yml
+cp examples/manifests/rendertrust.harness-manifest.yml .harness-manifest.yml
 ```
 
 ### Step 2: Fill in identity values
@@ -424,7 +417,7 @@ Each line in `.claude/.sync-exclude` becomes an entry in `protected`:
 # hooks-config.json
 # settings.local.json
 
-# After (.claude/.harness-manifest.yml):
+# After (.harness-manifest.yml):
 protected:
   - "hooks-config.json"
   - "settings.local.json"
@@ -444,9 +437,9 @@ shows more than 50% of lines changed, it is a replaced file.
 
 ### Step 6: Keep .sync-exclude (transitional)
 
-The `.sync-exclude` file can remain as a fallback during the v2.7.0
-transition period. The sync script checks the manifest first and only falls
-back to `.sync-exclude` if no manifest is found.
+The `.sync-exclude` file can remain during the transition period. When a
+manifest is present, its `protected` patterns are merged with `.sync-exclude`
+entries for backward compatibility.
 
 ---
 
@@ -463,15 +456,15 @@ for validating manifest files. Use any YAML-aware JSON Schema validator:
 
 # Python (check-jsonschema):
 pip install check-jsonschema
-check-jsonschema --schemafile .harness-manifest.schema.json .claude/.harness-manifest.yml
+check-jsonschema --schemafile .harness-manifest.schema.json .harness-manifest.yml
 
 # Node.js (ajv-cli):
-npx ajv-cli validate -s .harness-manifest.schema.json -d .claude/.harness-manifest.yml
+npx ajv-cli validate -s .harness-manifest.schema.json -d .harness-manifest.yml
 
 # VS Code / IDE
 # Add to .vscode/settings.json:
 # "yaml.schemas": {
-#   ".harness-manifest.schema.json": ".claude/.harness-manifest.yml"
+#   ".harness-manifest.schema.json": ".harness-manifest.yml"
 # }
 ```
 
@@ -497,7 +490,7 @@ The sync script performs runtime validation beyond what JSON Schema catches:
 ### Why a separate manifest file vs extending `.harness-sync.json`?
 
 - Separation of concerns: the manifest declares **what** the fork customized;
-  `.harness-sync.json` tracks **when** the last sync happened
+  `.harness-sync.json` (at repo root) tracks **when** the last sync happened
 - The manifest is committed to the repository; sync metadata is ephemeral
 - Different lifecycle: manifest changes rarely; sync metadata changes on
   every sync

--- a/docs/HARNESS_SYNC_GUIDE.md
+++ b/docs/HARNESS_SYNC_GUIDE.md
@@ -120,7 +120,7 @@ The sync script syncs only the directories declared in your manifest's
 safety check enforces that all target paths fall within a declared scope
 domain -- any file targeting a path outside the allowed domains causes
 the sync to abort. Use `--scope` to override the manifest scope for a
-single run (e.g., `--scope .claude/ .gemini/`).
+single run (e.g., `--scope .claude,.gemini`).
 
 Files that are always excluded from sync (hardcoded):
 
@@ -357,7 +357,7 @@ Renames are shown as `local-path (upstream: original-path)`.
 | `--version <tag>` | Sync to a specific release tag (e.g., `v2.7.0`) |
 | `--latest` | Sync to the most recent tagged release |
 | `--dry-run` | Preview changes without modifying any files |
-| `--scope <dirs...>` | Override manifest `sync_scope` for this run (e.g., `--scope .claude/ .gemini/`) |
+| `--scope <domains>` | Override manifest `sync_scope` for this run (e.g., `--scope .claude,.gemini`) |
 | `--no-placeholders` | Skip placeholder substitution (sync raw upstream files) |
 | `--skip-preflight` | Bypass preflight safety checks (advanced users only) |
 | `--generate-patches` | Generate `.patch` files instead of overwriting (see below) |

--- a/docs/HARNESS_SYNC_GUIDE.md
+++ b/docs/HARNESS_SYNC_GUIDE.md
@@ -1,10 +1,10 @@
 # Harness Sync Guide
 
-Keep your project's `.claude/` harness directory synchronized with the
+Keep your project's harness directories synchronized with the
 upstream [SAFe Agentic Workflow](https://github.com/ByBren-LLC/safe-agentic-workflow)
 repository using the manifest-based sync system.
 
-**Version**: 2.7.0 | **Scope**: `.claude/` directory only
+**Version**: 2.10.0 | **Scope**: Multi-domain (v2.10.0)
 
 ---
 
@@ -26,8 +26,8 @@ chmod +x scripts/sync-claude-harness.sh
 ./scripts/sync-claude-harness.sh init
 ```
 
-This creates `.claude/.harness-sync.json` (tracks upstream version and sync
-history) and `.claude/.sync-exclude` (legacy exclusion patterns).
+This creates `.harness-sync.json` at the repo root (tracks upstream version
+and sync history) and `.claude/.sync-exclude` (legacy exclusion patterns).
 
 ### 3. Create your manifest
 
@@ -76,8 +76,8 @@ Done. Your harness is updated and your project identity is preserved.
 When you run `sync`, the script performs these steps in order:
 
 1. **Load manifest** -- Reads `.harness-manifest.yml` and validates it
-   against the JSON schema. If no manifest exists, falls back to legacy
-   `.sync-exclude` behavior.
+   against the JSON schema. If no manifest exists, sync fails with an
+   error (except `--dry-run`, which is allowed for inspection).
 2. **Fetch upstream** -- Downloads the upstream `.claude/` directory as a
    tarball from the specified version or branch.
 3. **Apply substitutions** -- Replaces `{{PLACEHOLDER}}` tokens in upstream
@@ -112,22 +112,24 @@ Upstream repo                    Your fork
 
 ## Scope Contract
 
-**v2.7.0 sync operates exclusively on `.claude/`.**
+**v2.10.0 sync operates on any domain listed in `sync_scope`.**
 
-The sync script will never create, modify, or delete files outside of the
-`.claude/` directory. All paths in the manifest (`renames`, `protected`,
-`replaced`) are relative to `.claude/`. The preflight safety check enforces
-this boundary -- any file targeting a path outside `.claude/` causes the
-sync to abort.
+The sync script syncs only the directories declared in your manifest's
+`sync_scope` array (default: `[".claude/"]`). All paths in the manifest
+(`renames`, `protected`, `replaced`) are repo-root-relative. The preflight
+safety check enforces that all target paths fall within a declared scope
+domain -- any file targeting a path outside the allowed domains causes
+the sync to abort. Use `--scope` to override the manifest scope for a
+single run (e.g., `--scope .claude/ .gemini/`).
 
 Files that are always excluded from sync (hardcoded):
 
-- `.harness-sync.json` (sync metadata)
-- `.harness-manifest.yml` (manifest itself, via `.sync-exclude` metadata)
-- `.sync-exclude` (exclusion patterns)
+- `.harness-sync.json` (sync metadata, repo root)
+- `.harness-manifest.yml` (manifest itself, repo root)
+- `.sync-exclude` (legacy exclusion patterns)
 - `.sync-exclude.default`
-- `.harness-backup/*` (backup directory)
-- `.harness-patches/*` (generated patches)
+- `.harness-backup/` (backup directory, repo root)
+- `.harness-patches/` (generated patches, repo root)
 
 ---
 
@@ -295,8 +297,8 @@ All commands are run from your project root.
 ./scripts/sync-claude-harness.sh init
 ```
 
-Creates `.claude/.harness-sync.json` and `.claude/.sync-exclude`. Run this
-once after installing the sync script.
+Creates `.harness-sync.json` (repo root) and `.claude/.sync-exclude`. Run
+this once after installing the sync script.
 
 ### `status` -- Show sync status
 
@@ -355,6 +357,7 @@ Renames are shown as `local-path (upstream: original-path)`.
 | `--version <tag>` | Sync to a specific release tag (e.g., `v2.7.0`) |
 | `--latest` | Sync to the most recent tagged release |
 | `--dry-run` | Preview changes without modifying any files |
+| `--scope <dirs...>` | Override manifest `sync_scope` for this run (e.g., `--scope .claude/ .gemini/`) |
 | `--no-placeholders` | Skip placeholder substitution (sync raw upstream files) |
 | `--skip-preflight` | Bypass preflight safety checks (advanced users only) |
 | `--generate-patches` | Generate `.patch` files instead of overwriting (see below) |
@@ -371,7 +374,7 @@ Renames are shown as `local-path (upstream: original-path)`.
 ./scripts/sync-claude-harness.sh conflicts
 ```
 
-Lists any `.upstream` or `.conflict` files remaining in `.claude/`.
+Lists any `.upstream` or `.conflict` files remaining in synced domains.
 
 ### `rollback` -- Restore from backup
 
@@ -380,8 +383,8 @@ Lists any `.upstream` or `.conflict` files remaining in `.claude/`.
 ```
 
 Restores from the most recent timestamped backup at
-`.claude/.harness-backup/<timestamp>/`. The three most recent backups are
-retained; older ones are pruned automatically.
+`.harness-backup/<domain>/<timestamp>/`. The three most recent backups per
+domain are retained; older ones are pruned automatically.
 
 ---
 
@@ -470,8 +473,9 @@ is emitted (possible typo).
 
 Before every sync, an automatic preflight check validates three conditions:
 
-**(a) Scope check** -- All target files are within `.claude/`. Any path
-containing `../` or targeting outside `.claude/` causes an abort.
+**(a) Scope check** -- All target files are within a declared `sync_scope`
+domain. Any path containing `../` or targeting outside the allowed domains
+causes an abort.
 
 **(b) Token check** -- After substitution, no manifest keys remain as
 unreplaced `{{KEY}}` tokens. Each violation is reported with file and line
@@ -498,7 +502,7 @@ To bypass preflight (not recommended for normal use):
 
 ### Provenance Tracking
 
-After each sync, `.harness-sync.json` records full provenance:
+After each sync, `.harness-sync.json` (at repo root) records full provenance:
 
 ```json
 {
@@ -534,7 +538,7 @@ manual review and selective application:
 ./scripts/sync-claude-harness.sh sync --generate-patches --version v2.7.0
 ```
 
-Patches are written to `.claude/.harness-patches/v2.7.0/` with an
+Patches are written to `.harness-patches/v2.7.0/` with an
 `APPLY_ORDER.md` summary that groups patches by category (`NEW`,
 `UPDATED`) and lists `git apply` commands in recommended order.
 
@@ -551,13 +555,13 @@ Apply patches selectively:
 
 ```bash
 # Dry-run check (recommended first)
-git apply --check .claude/.harness-patches/v2.7.0/0001-agents-ui-engineer.patch
+git apply --check .harness-patches/v2.7.0/0001-agents-ui-engineer.patch
 
 # Apply a single patch
-git apply .claude/.harness-patches/v2.7.0/0001-agents-ui-engineer.patch
+git apply .harness-patches/v2.7.0/0001-agents-ui-engineer.patch
 
 # Apply all patches in order
-for patch in .claude/.harness-patches/v2.7.0/*.patch; do
+for patch in .harness-patches/v2.7.0/*.patch; do
   git apply "$patch"
 done
 ```
@@ -702,10 +706,10 @@ Common issues:
 
 ### Do I need a manifest to use the sync script?
 
-No. Without a manifest, the script uses legacy behavior: file-level copy
-with `.sync-exclude` pattern matching and no automatic substitution. The
-manifest enables smart sync features (renames, substitution, protected
-files, preflight checks, patch generation).
+Yes. As of v2.10.0, a manifest is required. Without one, sync fails with
+an error (except `--dry-run`, which is allowed for inspection). Run
+`./scripts/sync-claude-harness.sh manifest init` to auto-generate one
+from your project state.
 
 ### What happens if upstream restructures files I have renamed?
 
@@ -740,14 +744,17 @@ to accept.
 
 ### Where are backups stored?
 
-At `.claude/.harness-backup/<timestamp>/`. The three most recent backups
-are kept; older ones are pruned automatically after each sync.
+At `.harness-backup/<domain>/<timestamp>/` (repo root). The three most
+recent backups per domain are kept; older ones are pruned automatically
+after each sync.
 
 ### Can the sync script modify files outside `.claude/`?
 
-No. The v2.7.0 scope contract limits all operations to `.claude/`. The
-preflight check enforces this -- any path traversal attempt (e.g., `../`)
-aborts the sync immediately.
+Yes, as of v2.10.0. The sync script operates on any domain listed in your
+manifest's `sync_scope` (e.g., `.claude/`, `.gemini/`, `.codex/`). The
+preflight check enforces that all paths fall within declared scope domains
+-- any path traversal attempt (e.g., `../`) or write to an undeclared
+domain aborts the sync immediately.
 
 ### How do I validate my manifest before syncing?
 
@@ -806,12 +813,12 @@ Validate manifest on every PR:
 | File | Location | Purpose |
 | --- | --- | --- |
 | Sync script | `scripts/sync-claude-harness.sh` | The sync tool itself |
-| Manifest | `.harness-manifest.yml` | Fork customization declaration |
+| Manifest | `.harness-manifest.yml` | Fork customization declaration (repo root) |
 | JSON Schema | `.harness-manifest.schema.json` | Manifest validation schema |
-| Sync metadata | `.claude/.harness-sync.json` | Provenance and sync history |
+| Sync metadata | `.harness-sync.json` | Provenance and sync history (repo root) |
 | Legacy exclusions | `.claude/.sync-exclude` | Pre-manifest exclusion patterns |
-| Backups | `.claude/.harness-backup/` | Timestamped pre-sync backups |
-| Patches | `.claude/.harness-patches/<version>/` | Generated patch files |
+| Backups | `.harness-backup/<domain>/` | Timestamped pre-sync backups (repo root) |
+| Patches | `.harness-patches/<version>/` | Generated patch files (repo root) |
 | Schema docs | `docs/HARNESS_MANIFEST_SCHEMA.md` | Full schema reference |
 | Example (minimal) | `examples/manifests/rendertrust.harness-manifest.yml` | No renames, REN prefix |
 | Example (advanced) | `examples/manifests/keryk-ai.harness-manifest.yml` | Renames, replaced files |

--- a/docs/guides/WORKSPACE-ADOPTION-GUIDE.md
+++ b/docs/guides/WORKSPACE-ADOPTION-GUIDE.md
@@ -286,19 +286,22 @@ FACTORY_PROJECT_DIR="$(pwd)" ./dark-factory/scripts/factory-start.sh story {{TIC
 
 The harness has two update mechanisms:
 
-1. **`sync-claude-harness.sh`** — Syncs only the `.claude/` directory (skills,
-   commands, hooks, agents). This is the automated path.
-2. **Manual git checkout** — Updates everything else (docs, dark-factory,
-   scripts, patterns_library, Gemini harness). Required for full upgrades.
+1. **`sync-claude-harness.sh`** — Multi-domain sync (v2.10.0+). Syncs any
+   directories listed in your manifest's `sync_scope` (e.g., `.claude/`,
+   `.gemini/`, `.codex/`, `.cursor/`, `.agents/`, `dark-factory/`). A manifest
+   is required.
+2. **Manual git checkout** — Updates everything else (docs, scripts,
+   patterns_library). Required for full upgrades that include release-tier files.
 
-### Method 1: Sync Script (`.claude/` only)
+### Method 1: Sync Script (multi-domain)
 
-The sync script pulls upstream `.claude/` updates while preserving your
-project-specific customizations via `.claude/.sync-exclude`:
+The sync script pulls upstream updates for all declared scope domains while
+preserving your project-specific customizations via the manifest:
 
 ```bash
 # Initialize sync config (first time only)
 ./scripts/sync-claude-harness.sh init
+./scripts/sync-claude-harness.sh manifest init --yes
 
 # Check what version you're on
 ./scripts/sync-claude-harness.sh version
@@ -309,21 +312,18 @@ project-specific customizations via `.claude/.sync-exclude`:
 # Preview changes before applying
 ./scripts/sync-claude-harness.sh sync --dry-run
 
-# Apply a specific release
-./scripts/sync-claude-harness.sh sync --version v2.5.0
+# Apply a specific release (syncs all domains in sync_scope)
+./scripts/sync-claude-harness.sh sync --version v2.10.0
+
+# Or sync specific domains only
+./scripts/sync-claude-harness.sh sync --version v2.10.0 --scope .claude/ .gemini/
 
 # Or apply the latest release
 ./scripts/sync-claude-harness.sh sync --latest
 ```
 
-**Protect your customizations**: Edit `.claude/.sync-exclude` to list files
-that should never be overwritten:
-
-```
-# Example: keep your custom team config
-team-config.json
-settings.local.json
-```
+**Protect your customizations**: Use the `protected` section in your
+`.harness-manifest.yml` to list files that should never be overwritten.
 
 **If something breaks**: Roll back to the pre-sync backup:
 

--- a/docs/guides/WORKSPACE-ADOPTION-GUIDE.md
+++ b/docs/guides/WORKSPACE-ADOPTION-GUIDE.md
@@ -316,7 +316,7 @@ preserving your project-specific customizations via the manifest:
 ./scripts/sync-claude-harness.sh sync --version v2.10.0
 
 # Or sync specific domains only
-./scripts/sync-claude-harness.sh sync --version v2.10.0 --scope .claude/ .gemini/
+./scripts/sync-claude-harness.sh sync --version v2.10.0 --scope .claude,.gemini
 
 # Or apply the latest release
 ./scripts/sync-claude-harness.sh sync --latest

--- a/docs/releases/v2.10.0-UPGRADE.md
+++ b/docs/releases/v2.10.0-UPGRADE.md
@@ -1,0 +1,169 @@
+# Upgrading to v2.10.0 — Multi-Domain Sync
+
+## Overview
+
+v2.10.0 delivers multi-domain sync, completing the transition from `.claude/`-only
+sync to a manifest-driven engine that can sync any harness domain (`.claude/`,
+`.gemini/`, `.codex/`, `.cursor/`, `.agents/`, `dark-factory/`).
+
+## What Changed
+
+### Schema v1.1 (SAW-33)
+
+The manifest schema is now v1.1. Key additions:
+
+- **`sync_scope`**: Array of directories to sync from upstream (default: `[".claude/"]`)
+- **Root-relative paths**: All paths in `renames`, `protected`, `replaced` are now
+  repo-root-relative (e.g., `.claude/agents/bsa.md` instead of `agents/bsa.md`)
+- **Backward compat**: v1.0 manifests continue to work. Bare paths are normalized
+  by prepending `.claude/` during load.
+
+### Metadata Migration (SAW-34)
+
+Sync metadata files have moved from `.claude/` to the repo root:
+
+| Before (v2.9.0) | After (v2.10.0) |
+|------------------|-----------------|
+| `.claude/.harness-manifest.yml` | `.harness-manifest.yml` |
+| `.claude/.harness-sync.json` | `.harness-sync.json` |
+| `.claude/.harness-backup/<timestamp>/` | `.harness-backup/<domain>/<timestamp>/` |
+| `.claude/.harness-patches/<version>/` | `.harness-patches/<version>/` |
+
+**Migration is automatic.** When you run `sync` or `manifest init`, the script
+detects metadata at the old `.claude/` locations and moves it to the repo root.
+No manual action is required.
+
+### Multi-Domain Sync Engine (SAW-35)
+
+The sync script now reads your manifest's `sync_scope` and syncs all listed
+domains in a single run:
+
+```bash
+# Syncs all domains in sync_scope
+./scripts/sync-claude-harness.sh sync --version v2.10.0
+
+# Override scope for a single run
+./scripts/sync-claude-harness.sh sync --version v2.10.0 --scope .claude/ .gemini/
+```
+
+### Manifest Required
+
+Sync now requires a manifest. Without one, sync fails with an error. The only
+exception is `--dry-run`, which is allowed without a manifest for inspection.
+
+If you do not have a manifest yet:
+
+```bash
+./scripts/sync-claude-harness.sh manifest init --yes
+```
+
+The `manifest init` command auto-detects which provider domains exist in your
+repo and proposes an initial `sync_scope`.
+
+## Upgrade Steps
+
+### From v2.9.0 (manifest already exists)
+
+```bash
+# 1. Sync to v2.10.0 (metadata migration happens automatically)
+./scripts/sync-claude-harness.sh sync --version v2.10.0 --dry-run
+./scripts/sync-claude-harness.sh sync --version v2.10.0
+
+# 2. (Optional) Expand sync_scope to include additional domains
+#    Edit .harness-manifest.yml:
+#    sync:
+#      sync_scope:
+#        - ".claude/"
+#        - ".gemini/"
+#        - ".codex/"
+
+# 3. Bump manifest_version to 1.1 (recommended, not required)
+#    manifest_version: "1.1"
+
+# 4. Verify metadata moved to repo root
+ls .harness-manifest.yml .harness-sync.json
+```
+
+### From v2.7.0 or v2.8.x (no manifest)
+
+```bash
+# 1. Initialize sync metadata
+./scripts/sync-claude-harness.sh init
+
+# 2. Generate manifest (auto-detects domains and identity values)
+./scripts/sync-claude-harness.sh manifest init --yes
+
+# 3. Preview and apply
+./scripts/sync-claude-harness.sh sync --version v2.10.0 --dry-run
+./scripts/sync-claude-harness.sh sync --version v2.10.0
+```
+
+### From pre-v2.7.0 (legacy .sync-exclude)
+
+```bash
+# 1. Initialize sync metadata
+./scripts/sync-claude-harness.sh init
+
+# 2. Generate manifest
+./scripts/sync-claude-harness.sh manifest init --yes
+
+# 3. Migrate .sync-exclude entries to manifest protected section
+#    See docs/HARNESS_SYNC_GUIDE.md "Migration from .sync-exclude"
+
+# 4. Preview and apply
+./scripts/sync-claude-harness.sh sync --version v2.10.0 --dry-run
+./scripts/sync-claude-harness.sh sync --version v2.10.0
+```
+
+## Domain Detection During `manifest init`
+
+The `manifest init` command inspects your repo for known provider directories
+and proposes a `sync_scope`. Detection logic:
+
+| Directory | Condition | Tier |
+|-----------|-----------|------|
+| `.claude/` | Always included | Provider |
+| `.gemini/` | Present with `GEMINI.md` or `settings.json` | Provider |
+| `.codex/` | Present with `config.toml` | Provider |
+| `.cursor/` | Present with `rules/` subdirectory | Provider |
+| `.agents/` | Present with `skills/` subdirectory | Shared |
+| `dark-factory/` | Present with `scripts/` subdirectory | Shared |
+
+You can edit the generated `sync_scope` to add or remove domains after init.
+
+## Verification
+
+```bash
+# Confirm metadata at repo root
+test -f .harness-manifest.yml && echo "Manifest: OK" || echo "Manifest: MISSING"
+test -f .harness-sync.json && echo "Sync metadata: OK" || echo "Sync metadata: MISSING"
+
+# Confirm no stale metadata in .claude/
+test ! -f .claude/.harness-manifest.yml && echo "Old manifest: cleaned" || echo "WARNING: stale .claude/.harness-manifest.yml"
+test ! -f .claude/.harness-sync.json && echo "Old sync meta: cleaned" || echo "WARNING: stale .claude/.harness-sync.json"
+
+# Check sync scope
+grep -A 10 'sync_scope' .harness-manifest.yml
+```
+
+## Rollback
+
+If issues arise, restore from the domain-organized backups:
+
+```bash
+# List available backups
+ls .harness-backup/
+
+# Restore a specific domain from backup
+cp -r .harness-backup/.claude/<timestamp>/* .claude/
+
+# Or use the sync script rollback
+./scripts/sync-claude-harness.sh rollback
+```
+
+To fully revert to v2.9.0 behavior:
+
+```bash
+git fetch harness --tags
+git checkout v2.9.0 -- .claude/ .gemini/ .codex/ .cursor/ .agents/ dark-factory/
+```

--- a/docs/releases/v2.10.0-UPGRADE.md
+++ b/docs/releases/v2.10.0-UPGRADE.md
@@ -43,7 +43,7 @@ domains in a single run:
 ./scripts/sync-claude-harness.sh sync --version v2.10.0
 
 # Override scope for a single run
-./scripts/sync-claude-harness.sh sync --version v2.10.0 --scope .claude/ .gemini/
+./scripts/sync-claude-harness.sh sync --version v2.10.0 --scope .claude,.gemini
 ```
 
 ### Manifest Required
@@ -120,14 +120,17 @@ ls .harness-manifest.yml .harness-sync.json
 The `manifest init` command inspects your repo for known provider directories
 and proposes a `sync_scope`. Detection logic:
 
-| Directory | Condition | Tier |
-|-----------|-----------|------|
-| `.claude/` | Always included | Provider |
-| `.gemini/` | Present with `GEMINI.md` or `settings.json` | Provider |
-| `.codex/` | Present with `config.toml` | Provider |
-| `.cursor/` | Present with `rules/` subdirectory | Provider |
-| `.agents/` | Present with `skills/` subdirectory | Shared |
-| `dark-factory/` | Present with `scripts/` subdirectory | Shared |
+| Directory | Detected when | Tier |
+|-----------|---------------|------|
+| `.claude/` | Directory exists | Provider |
+| `.gemini/` | Directory exists | Provider |
+| `.codex/` | Directory exists | Provider |
+| `.cursor/` | Directory exists | Provider |
+| `.agents/` | Directory exists | Shared |
+| `dark-factory/` | Directory exists | Shared |
+
+Detection is simple directory existence — if the directory is present in your project,
+it's included in the proposed `sync_scope`. No file-level checks are performed.
 
 You can edit the generated `sync_scope` to add or remove domains after init.
 

--- a/scripts/setup-template.sh
+++ b/scripts/setup-template.sh
@@ -83,7 +83,7 @@ read -rp "Container registry (e.g., ghcr.io/acme-corp): " CONTAINER_REGISTRY
 TICKET_PREFIX_LOWER=$(echo "$TICKET_PREFIX" | tr '[:upper:]' '[:lower:]')
 AUTHOR_INITIALS="${AUTHOR_FIRST_NAME:0:1}. ${AUTHOR_LAST_NAME:0:1}."
 GITHUB_REPO_URL="https://github.com/${GITHUB_ORG}/${PROJECT_REPO}"
-HARNESS_VERSION="v2.9.0"
+HARNESS_VERSION="v2.10.0"
 
 echo ""
 echo "--- Review your values ---"


### PR DESCRIPTION
## Summary

Final story for SAW-11: documentation update + version bump for v2.10.0 release.

- **Linear**: [SAW-38](https://linear.app/cheddarfox/issue/SAW-38)
- **Parent**: [SAW-11](https://linear.app/cheddarfox/issue/SAW-11)

### Documentation Updates
- **HARNESS_SYNC_GUIDE.md**: v2.10.0 multi-domain scope, removed ".claude/ only" (27+ stale refs)
- **HARNESS_MANIFEST_SCHEMA.md**: removed all "planned/future/SAW-34/SAW-35" banners
- **WORKSPACE-ADOPTION-GUIDE.md**: multi-domain sync, manifest required
- **.codex/README.md** + **.gemini/README.md**: added sync capability notes
- **v2.10.0-UPGRADE.md**: new upgrade guide (schema v1.1, migration, multi-domain usage)

### Version Bump
- CITATION.cff/bib: v2.10.0, SAW title, scott@cheddarfox.com, ByBren LLC
- setup-template.sh: HARNESS_VERSION v2.10.0
- README badge: v2.10.0

### Citations
- Title: "SAW — SAFe Agentic Workflow" (matches README)
- Author: J. Scott Graham (@cheddarfox)
- Organization: ByBren, LLC

## Test Plan
- [x] Zero stale ".claude/ only" references in updated docs
- [x] Existing tests pass (fork-sync: 61/61)
- [x] v2.10.0 upgrade guide created

🤖 Generated with [Claude Code](https://claude.com/claude-code)