### PR TITLE
fix(setup): avoid xargs shell function call [SAW-46]

### DIFF
--- a/scripts/setup-template.sh
+++ b/scripts/setup-template.sh
@@ -165,7 +165,9 @@ for pair in "${REPLACEMENTS[@]}"; do
   echo "  Replacing '$OLD' → '$NEW'"
 
   # Find all text files, excluding .git and node_modules
-  find "$REPO_ROOT" \
+  while IFS= read -r -d '' file; do
+    _sed_inplace "s|${OLD}|${NEW}|g" "$file"
+  done < <(find "$REPO_ROOT" \
     -type f \
     \( -name "*.md" -o -name "*.json" -o -name "*.yml" -o -name "*.yaml" \
        -o -name "*.sh" -o -name "*.py" -o -name "*.txt" -o -name "*.toml" \
@@ -174,7 +176,7 @@ for pair in "${REPLACEMENTS[@]}"; do
        -o -name ".env.template" -o -name ".gitignore" \) \
     ! -path "*/.git/*" \
     ! -path "*/node_modules/*" \
-    -print0 | xargs -0 _sed_inplace "s|${OLD}|${NEW}|g"
+    -print0)
 done
 
 echo ""


### PR DESCRIPTION
## Summary

Fixes #46 by avoiding the `xargs -0 _sed_inplace ...` call in `scripts/setup-template.sh`.

`_sed_inplace` is a Bash function, so `xargs` cannot invoke it as an external executable. The replacement loop now keeps the existing `find -print0` behavior for filenames with spaces, but reads each file path in Bash and calls `_sed_inplace` directly.

## Changes Made

- Replaced the `find ... | xargs -0 _sed_inplace ...` pipeline with a null-delimited Bash `while read -d ''` loop.
- Kept the existing GNU/BSD sed compatibility helper and text-file filters unchanged.

## Testing

```bash
bash -n scripts/setup-template.sh
```

```bash
rm -rf /tmp/codex-community-249/verify-setup-2
rsync -a --exclude .git /tmp/codex-community-249/safe-agentic-workflow/ /tmp/codex-community-249/verify-setup-2/
cd /tmp/codex-community-249/verify-setup-2
printf "%s\n" \
  demo-app demo-app DEMO example.test demo-org "Demo Org" \
  "Demo User" Demo User demouser demo@example.test https://example.test security@example.test \
  architect DEMO demo main linear-mcp confluence-mcp \
  demo_user demo_password demo_db demo-postgres demo-dev demo-staging ghcr.io/demo-org \
  y n | bash scripts/setup-template.sh
```

Result: `SETUP_RC=0`; replacements completed, template-only files were cleaned up, and the script reached the "Setup complete" message.

```bash
bash tests/test-manifest-loader.sh
```

Result: 24 passed, 0 failed.

Known unrelated local limit: `tests/test-substitutions.sh` reaches `tests/test-rename-diff.sh`, which fails on this macOS runner because the mocked script is executed by a shell path that does not support `declare -A`. The direct setup-template regression check above covers this fix.
