### PR TITLE
feat(harness): add SAFe x AI-DLC methodology layer [SAW-39]

### DIFF
--- a/.agents/skills/linear-sop/SKILL.md
+++ b/.agents/skills/linear-sop/SKILL.md
@@ -69,6 +69,60 @@ create_comment({
 })
 ```
 
+## Program Structure
+
+For work that spans many issues, most trackers have objects **above** the issue. Use them; do not
+flatten a program into a flat list of tickets.
+
+### The Hierarchy
+
+```text
+Initiative          the program (one per program)
+  └── Project       a Unit of Work — one coherent outcome
+       ├── Milestone    an AI-DLC phase: Inception, Construction, Operations
+       └── Issue        a Story
+            └── Sub-issue   a Mob Elaboration task (created during Inception, not before)
+```
+
+### Prerequisite: labels must already exist
+
+Program build-out assumes these label namespaces are **pre-created in the workspace**. Create them
+before building the program, not during:
+
+- `bolt:0` … `bolt:N` — which Bolt an issue belongs to
+- `agent:*` — the lead role (must match an actual agent role defined for the project)
+
+Where the tracker scopes labels globally, do not create per-team duplicates.
+
+### Streams
+
+Some trackers gate sub-initiatives behind a paid tier. Where sub-initiatives are available, model
+program streams as sub-initiatives under the initiative. Where they are not, encode the stream as
+**project priority** instead — highest-risk stream gets Urgent/High, follow-up stream gets Medium.
+Both are valid; pick based on what your tracker supports.
+
+### Dependency Wiring
+
+Build the dependency DAG with issue relations:
+
+```text
+update_issue({
+  id: "{{TICKET_PREFIX}}-XXX",
+  blocks: ["{{TICKET_PREFIX}}-YYY"],       // this issue must land first
+  blockedBy: ["{{TICKET_PREFIX}}-ZZZ"],    // this issue waits on that one
+})
+```
+
+Use `relatedTo` for soft links that inform but do not block.
+
+**Wire so the enforcement lands before the thing it enforces** — see the `safe-ai-dlc` skill for the
+four dependency-wiring heuristics.
+
+### Re-parenting existing issues
+
+When a program absorbs tickets that already exist, **update them into the project — never recreate
+them**. Duplicates break traceability and split the evidence trail.
+
 ## Evidence Policy (MUST)
 
 Every issue requires evidence at each phase:

--- a/.agents/skills/safe-ai-dlc/SKILL.md
+++ b/.agents/skills/safe-ai-dlc/SKILL.md
@@ -39,7 +39,7 @@ human-in-the-loop.
 | Epic/value stream | Program stream                        | Sub-initiative, or project priority     |
 | Feature           | Unit of Work                          | Project                                 |
 | PI increment      | Bolt                                  | `bolt:N` label + target date            |
-| Phase gate        | Inception / Construction / Operations | Project milestone (3 per project)       |
+| Phase gate        | Inception / Construction / Operations | Project Milestone (3 per project)       |
 | Story/Enabler     | Story                                 | Issue                                   |
 | Task              | Mob task                              | Sub-issue                               |
 | WSJF/Role/DoD     | prioritization / mob role / gate      | description + `agent:*` labels + AC/DoD |

--- a/.agents/skills/safe-ai-dlc/SKILL.md
+++ b/.agents/skills/safe-ai-dlc/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: safe-ai-dlc
+description: >
+  Plan and run programs using the SAFe x AI-DLC fusion. Use when turning an
+  audit, epic, or initiative into tracker structure (initiative, projects,
+  milestones, issues, sub-issues), organizing work as Units of Work and Bolts,
+  wiring a dependency DAG, or running a Bolt swarm with a human-in-the-loop
+  gate. Applies when work spans multiple issues and needs cadence.
+---
+
+# SAFe x AI-DLC Skill
+
+> **TEMPLATE**: This skill uses `{{PLACEHOLDER}}` tokens. Replace with your project values before use.
+
+## Purpose
+
+Encode the SAFe x AI-DLC fusion so agents structure multi-issue programs consistently: SAFe supplies
+the hierarchy and guardrails, AI-DLC supplies the cadence and the human checkpoint. Sprints are
+replaced by **Bolts** because agent teams elaborate, build, and verify in hours, not weeks.
+
+## When This Skill Applies
+
+- Turning an audit, epic, or initiative into an executable program
+- Structuring work in the tracker as initiative, projects, milestones, issues, and sub-issues
+- Breaking an initiative into Units of Work and sequencing them into Bolts
+- Wiring dependencies so gates land before the fixes they verify
+- Running a Bolt: elaborate, validate with the human, construct, verify gates are real, evidence, merge
+
+Do NOT use it for a single isolated ticket with no program context — use `safe-workflow` for that.
+
+## The Fusion Model
+
+SAFe gives hierarchy, WSJF, roles, DoD, and dependencies. AI-DLC gives cadence (Bolts) and the
+human-in-the-loop.
+
+| SAFe              | AI-DLC                                | Tracker object                          |
+| ----------------- | ------------------------------------- | --------------------------------------- |
+| Portfolio Epic    | The Program                           | Initiative                              |
+| Epic/value stream | Program stream                        | Sub-initiative, or project priority     |
+| Feature           | Unit of Work                          | Project                                 |
+| PI increment      | Bolt                                  | `bolt:N` label + target date            |
+| Phase gate        | Inception / Construction / Operations | Project milestone (3 per project)       |
+| Story/Enabler     | Story                                 | Issue                                   |
+| Task              | Mob task                              | Sub-issue                               |
+| WSJF/Role/DoD     | prioritization / mob role / gate      | description + `agent:*` labels + AC/DoD |
+
+**The loop:** AI plans, AI asks clarifying questions, the **HUMAN validates business context**, then
+AI executes. Never skip the human validation step.
+
+## How to Structure the Program
+
+Build top-down:
+
+1. **Initiative** = the program. One per program.
+2. **Projects** = Units of Work. One coherent outcome each.
+3. **Milestones** = the three AI-DLC phases (Inception, Construction, Operations). Create all three
+   per project.
+4. **Issues** = Stories. Each carries the issue template below. Label with `bolt:N` and `agent:*`
+   (lead role).
+5. **Sub-issues** = Mob Elaboration tasks. Create during Inception, not before.
+6. **Dependencies** = `blocks` / `blockedBy` edges forming the dependency DAG.
+
+Program streams map to **sub-initiatives** where the tracker plan supports them; where it does not,
+encode the stream as **project priority** instead (highest-risk stream = Urgent/High).
+
+Use `linear-sop` for tracker operations, label prerequisites, and evidence templates.
+
+## Issue Template
+
+Every issue description block contains:
+
+```text
+Header:      <ID> — <title>  [{{TICKET_PREFIX}}-XXX]
+WSJF:        <score>   MoSCoW: <Must|Should|Could|Won't>
+Finding:     <source refs, e.g. audit finding IDs>
+Phase:       <Inception | Construction | Operations>
+Bolt:        <bolt:N>
+Role:        <agent:* lead>
+AC:          - acceptance criterion (testable)
+DoD:         - merged to {{MAIN_BRANCH}}; relevant gate REAL and green; evidence in tracker;
+               no silent suppression
+Deps:        blocks: [...]   blockedBy: [...]
+Sub-issues:  (Mob Elaboration tasks, added during Inception)
+```
+
+## Dependency-Wiring Rules
+
+Wire `blocks` / `blockedBy` so the enforcement lands **before** the thing it enforces:
+
+- **Fix the gate before the fix it verifies.** Harden CI or un-mask a check before landing the fix
+  that check is supposed to catch.
+- **Rotate before scrub.** Rotate a leaked credential before scrubbing it from history.
+- **Capture before alert.** Error capture or health check blocks the alerter and the poller built on
+  top of it.
+- **Upgrades before re-baseline.** Framework and SDK upgrades block audit re-baselining, which blocks
+  the scheduled recurring audit.
+
+Dependency chains are usually rooted at CI hardening — one keystone issue tends to unblock a whole
+stream. Identify it and sequence its Bolt first.
+
+## Running a Bolt
+
+1. **Open and elaborate** every issue in the Bolt (Mob Elaboration: sub-issues, unknowns, questions).
+2. **Validate with the human** on all business, security, and policy decisions before Construction.
+3. **Construct** in dependency order on `{{TICKET_PREFIX}}-` branches with SAFe commits, rebase-first.
+4. **Verify gates are real** — a green check that still masks a failure is not an exit.
+5. **Post evidence** to the tracker (dev/staging/done) per `linear-sop`.
+6. **Merge** — RTE prepares the PR; the human (HITL) merges. Exit = merged + real gates green +
+   evidence posted.
+
+## Human-Gate Checklist
+
+Route to the human, with options and a recommendation, whenever a decision is:
+
+- A **secret or credential** action (what to rotate, when, blast radius)
+- A **security policy**: CSP allow-list, auth behavior, headers
+- A **CI or branch-protection** decision: which checks become required
+- A **severity or risk policy**: dependency-audit thresholds, fix-vs-suppress budget
+- An **SOP exception** (e.g. a migration deviating from the documented process)
+- **Signing the Definition of Done**
+
+If a decision changes business, security, or risk posture, it is the human's — surface, recommend,
+stop.
+
+## Anti-Patterns (Do NOT use)
+
+```text
+Forcing an ambiguous epic into one Bolt    (run a spike instead — elaboration is the hard part)
+Creating sub-issues before Inception       (Mob Elaboration produces them, not the other way round)
+Bolts as calendar sprints                  (a Bolt exits on evidence, not on a date)
+Skipping human validation to move faster   (the loop is the method; without it this is just SAFe)
+Treating a green check as an exit          (verify the gate enforces, not that it merely passed)
+```
+
+## Reference
+
+- **Methodology guide**: `/docs/guides/SAFE-AI-DLC-METHODOLOGY.md`
+- **Program template**: `/specs_templates/program_template.md`
+- **AI-DLC source**: <https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/>
+
+## Routes To
+
+- `linear-sop` — tracker operations, program structure, evidence templates
+- `safe-workflow` — branch, commit, and PR conventions; HITL merge
+- `orchestration-patterns` — multi-agent swarm coordination for a Bolt
+- `pattern-discovery` — find existing code and doc patterns before constructing

--- a/.agents/skills/safe-ai-dlc/SKILL.md
+++ b/.agents/skills/safe-ai-dlc/SKILL.md
@@ -134,8 +134,8 @@ Treating a green check as an exit          (verify the gate enforces, not that i
 
 ## Reference
 
-- **Methodology guide**: `/docs/guides/SAFE-AI-DLC-METHODOLOGY.md`
-- **Program template**: `/specs_templates/program_template.md`
+- `docs/guides/SAFE-AI-DLC-METHODOLOGY.md` -- Methodology guide (rationale, worked example)
+- `specs_templates/program_template.md` -- Program document scaffolding
 - **AI-DLC source**: <https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/>
 
 ## Routes To

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -243,11 +243,12 @@ Scripts in `.claude/hooks/` that are actively wired via `hooks-config.json`:
 
 Skills are model-invoked expertise packs that Claude loads automatically when relevant context is detected.
 
-### Skills Index (18 Skills)
+### Skills Index (19 Skills)
 
 | Skill | Purpose | Related Skills |
 |-------|---------|----------------|
 | [safe-workflow](skills/safe-workflow/) | Branch naming, commit format, PR workflow | release-patterns, git-advanced |
+| [safe-ai-dlc](skills/safe-ai-dlc/) | Program cadence: Units of Work, Bolts, human-in-the-loop gate | linear-sop, safe-workflow, orchestration-patterns |
 | [release-patterns](skills/release-patterns/) | PR creation, CI/CD validation | safe-workflow, deployment-sop |
 | [pattern-discovery](skills/pattern-discovery/) | Search patterns before implementing | api-patterns, frontend-patterns |
 | [agent-coordination](skills/agent-coordination/) | Agent assignment, blocker escalation | orchestration-patterns, linear-sop |

--- a/.claude/SETUP.md
+++ b/.claude/SETUP.md
@@ -22,7 +22,7 @@ This guide helps you install the SAFe Claude Code harness in a new project.
 # Copy slash commands (24 commands)
 cp -r .claude/commands/ /path/to/your-project/.claude/commands/
 
-# Copy skills (18 model-invoked skills)
+# Copy skills (19 model-invoked skills)
 cp -r .claude/skills/ /path/to/your-project/.claude/skills/
 
 # Copy agent profiles (11 SAFe agents)
@@ -124,7 +124,7 @@ Ask Claude:
 What skills are available?
 ```
 
-Expected: List of 18 skills with descriptions.
+Expected: List of 19 skills with descriptions.
 
 **Known Issue (v2.0.73)**: The `/skills` command has a display bug. Skills work correctly but won't appear in `/skills` output. Ask Claude directly instead.
 
@@ -183,7 +183,7 @@ After setup, your `.claude/` directory should look like:
 │   ├── pre-pr.md
 │   ├── end-work.md
 │   └── ... (21 more)
-├── skills/             # 18 model-invoked skills
+├── skills/             # 19 model-invoked skills
 │   ├── safe-workflow/SKILL.md
 │   ├── pattern-discovery/SKILL.md
 │   ├── rls-patterns/SKILL.md

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -19,6 +19,7 @@ SAFe® is a registered trademark of Scaled Agile, Inc.
 | Skill | Purpose |
 |-------|---------|
 | safe-workflow | Branch naming, commits, PR workflow |
+| safe-ai-dlc | Program cadence: Units of Work, Bolts, human-in-the-loop gate |
 | release-patterns | PR creation, CI/CD validation |
 | pattern-discovery | Search patterns before implementing |
 | agent-coordination | Agent assignment, blockers |

--- a/.claude/skills/linear-sop/README.md
+++ b/.claude/skills/linear-sop/README.md
@@ -41,6 +41,7 @@ Guides consistent Linear ticket management with evidence templates for the manda
 
 - [orchestration-patterns](../orchestration-patterns/) - Evidence-based delivery
 - [agent-coordination](../agent-coordination/) - Ticket assignment
+- [safe-ai-dlc](../safe-ai-dlc/) - Program structure: initiatives, Units of Work, Bolts
 
 ## Maintenance
 

--- a/.claude/skills/linear-sop/SKILL.md
+++ b/.claude/skills/linear-sop/SKILL.md
@@ -66,6 +66,60 @@ mcp__{{MCP_LINEAR_SERVER}}__create_comment({
 })
 ```
 
+## Program Structure
+
+For work that spans many issues, Linear has objects **above** the issue. Use them; do not flatten a
+program into a flat list of tickets.
+
+### The Hierarchy
+
+```text
+Initiative          the program (one per program)
+  └── Project       a Unit of Work — one coherent outcome
+       ├── Milestone    an AI-DLC phase: Inception, Construction, Operations
+       └── Issue        a Story
+            └── Sub-issue   a Mob Elaboration task (created during Inception, not before)
+```
+
+### Prerequisite: labels must already exist
+
+Program build-out assumes these label namespaces are **pre-created in the workspace**. Create them
+before building the program, not during:
+
+- `bolt:0` … `bolt:N` — which Bolt an issue belongs to
+- `agent:*` — the lead role (must match an actual agent name in `.claude/agents/`)
+
+Labels are workspace-scoped in Linear — do not create team-scoped duplicates.
+
+### Streams
+
+Linear **sub-initiatives require an Enterprise plan**. If your workspace has it, model program
+streams as sub-initiatives under the initiative. If it does not, encode the stream as **project
+priority** instead — highest-risk stream gets Urgent/High, follow-up stream gets Medium. Both are
+valid; pick based on your plan tier.
+
+### Dependency Wiring
+
+Build the dependency DAG with issue relations:
+
+```text
+mcp__{{MCP_LINEAR_SERVER}}__update_issue({
+  id: "{{TICKET_PREFIX}}-XXX",
+  blocks: ["{{TICKET_PREFIX}}-YYY"],       // this issue must land first
+  blockedBy: ["{{TICKET_PREFIX}}-ZZZ"],    // this issue waits on that one
+})
+```
+
+Use `relatedTo` for soft links that inform but do not block.
+
+**Wire so the enforcement lands before the thing it enforces** — see the `safe-ai-dlc` skill for the
+four dependency-wiring heuristics.
+
+### Re-parenting existing issues
+
+When a program absorbs tickets that already exist, **update them into the project — never recreate
+them**. Duplicates break traceability and split the evidence trail.
+
 ## Evidence Policy (MUST)
 
 Every issue requires evidence at each phase:

--- a/.claude/skills/safe-ai-dlc/README.md
+++ b/.claude/skills/safe-ai-dlc/README.md
@@ -1,0 +1,61 @@
+# SAFe x AI-DLC
+
+![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-{{HARNESS_VERSION}}-blue)
+
+> Plan and run programs using the SAFe x AI-DLC fusion. Structures an audit or initiative into Linear as Units of Work and Bolts, with a human-in-the-loop gate.
+
+## License
+
+**License:** MIT (see [/LICENSE](/LICENSE))
+**Copyright:** © 2026 J. Scott Graham ([@cheddarfox](https://github.com/cheddarfox)) / [ByBren, LLC](https://github.com/bybren-llc)
+**Attribution:** Required per [/NOTICE](/NOTICE)
+
+## Intellectual Property
+
+The skill system architecture and {{PROJECT_SHORT}} harness methodology are the intellectual property of J. Scott Graham and ByBren, LLC.
+
+SAFe® is a registered trademark of Scaled Agile, Inc.
+
+## Quick Start
+
+This skill activates automatically when you:
+
+- Turn an audit, epic, or initiative into an executable program
+- Structure work in Linear above the level of a single issue
+- Break an initiative into Units of Work and sequence them into Bolts
+- Wire a dependency DAG across issues
+- Run a Bolt from elaboration through to HITL merge
+
+## What This Skill Does
+
+Encodes the fusion of SAFe structure with the AI-DLC delivery cadence. SAFe supplies the hierarchy, WSJF, role boundaries, and Definition of Done; AI-DLC supplies **Bolts** (hours-to-days swarms that replace sprints), **Units of Work**, **Mob Elaboration**, and the plan → clarify → validate → execute loop with a human checkpoint in the middle.
+
+Provides the Linear mapping (initiative → project → milestone → issue → sub-issue), the issue template, four dependency-wiring heuristics, the six steps of running a Bolt, and the human-gate checklist that keeps agents from guessing business, security, or policy decisions.
+
+## Trigger Keywords
+
+| Primary      | Secondary       |
+| ------------ | --------------- |
+| bolt         | program         |
+| unit of work | initiative      |
+| AI-DLC       | mob elaboration |
+| remediation  | dependency DAG  |
+
+## Related Skills
+
+- [linear-sop](../linear-sop/) - Program structure, MCP calls, evidence templates
+- [safe-workflow](../safe-workflow/) - Branch, commit, and PR conventions
+- [orchestration-patterns](../orchestration-patterns/) - Multi-agent coordination during a Bolt
+- [pattern-discovery](../pattern-discovery/) - Find patterns before constructing
+
+## Maintenance
+
+| Field           | Value                 |
+| --------------- | --------------------- |
+| Last Updated    | 2026-07-19            |
+| Harness Version | {{HARNESS_VERSION}}   |
+
+---
+
+*Full implementation details in [SKILL.md](SKILL.md)*

--- a/.claude/skills/safe-ai-dlc/SKILL.md
+++ b/.claude/skills/safe-ai-dlc/SKILL.md
@@ -31,8 +31,7 @@ Do NOT use it for a single isolated ticket with no program context — use `safe
 ## The Fusion Model
 
 SAFe gives hierarchy, WSJF, roles, DoD, and dependencies. AI-DLC gives cadence (Bolts) and the
-human-in-the-loop. See the [methodology guide](/docs/guides/SAFE-AI-DLC-METHODOLOGY.md) for the full
-rationale.
+human-in-the-loop. See `docs/guides/SAFE-AI-DLC-METHODOLOGY.md` for the full rationale.
 
 | SAFe               | AI-DLC                                | Linear                                    |
 | ------------------ | ------------------------------------- | ----------------------------------------- |
@@ -135,8 +134,8 @@ Treating a green check as an exit          (verify the gate enforces, not that i
 
 ## Authoritative References
 
-- **Methodology guide**: `/docs/guides/SAFE-AI-DLC-METHODOLOGY.md`
-- **Program template**: `/specs_templates/program_template.md`
+- `docs/guides/SAFE-AI-DLC-METHODOLOGY.md` -- Methodology guide (rationale, worked example)
+- `specs_templates/program_template.md` -- Program document scaffolding
 - **AI-DLC source**: <https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/>
 
 ## Routes To

--- a/.claude/skills/safe-ai-dlc/SKILL.md
+++ b/.claude/skills/safe-ai-dlc/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: safe-ai-dlc
+description: Plan and run programs using the SAFe x AI-DLC fusion. Use when turning an audit, epic, or initiative into Linear structure (initiative, projects, milestones, issues, sub-issues), organizing work as Units of Work and Bolts, wiring a dependency DAG, or running a Bolt swarm with a human-in-the-loop gate. Applies when work spans multiple issues and needs cadence, not just a single ticket.
+user-invocable: false
+allowed-tools: Read, Grep, Glob
+---
+
+# SAFe x AI-DLC Skill
+
+> **📋 TEMPLATE**: This skill uses `{{TICKET_PREFIX}}` and `{{MAIN_BRANCH}}` as placeholders.
+> Replace with your project's ticket prefix (e.g., `WOR`, `PROJ`) and base branch (e.g., `dev`, `main`).
+
+## Purpose
+
+Encode the SAFe x AI-DLC fusion so agents structure multi-issue programs consistently: SAFe supplies
+the hierarchy and guardrails, AI-DLC supplies the cadence and the human checkpoint. Sprints are
+replaced by **Bolts** because agent teams elaborate, build, and verify in hours, not weeks.
+
+## When This Skill Applies
+
+Invoke this skill when:
+
+- Turning an audit, epic, or initiative into an executable program
+- Structuring work in Linear as initiative, projects, milestones, issues, and sub-issues
+- Breaking an initiative into Units of Work and sequencing them into Bolts
+- Wiring dependencies so gates land before the fixes they verify
+- Running a Bolt: elaborate, validate with the human, construct, verify gates are real, evidence, merge
+
+Do NOT use it for a single isolated ticket with no program context — use `safe-workflow` for that.
+
+## The Fusion Model
+
+SAFe gives hierarchy, WSJF, roles, DoD, and dependencies. AI-DLC gives cadence (Bolts) and the
+human-in-the-loop. See the [methodology guide](/docs/guides/SAFE-AI-DLC-METHODOLOGY.md) for the full
+rationale.
+
+| SAFe               | AI-DLC                                | Linear                                    |
+| ------------------ | ------------------------------------- | ----------------------------------------- |
+| Portfolio Epic     | The Program                           | Initiative                                |
+| Epic/value stream  | Program stream                        | Sub-initiative, or project priority       |
+| Feature            | Unit of Work                          | Project                                   |
+| PI increment       | Bolt                                  | `bolt:N` label + target date              |
+| Phase gate         | Inception / Construction / Operations | Project Milestone (3 per project)         |
+| Story/Enabler      | Story                                 | Issue                                     |
+| Task               | Mob task                              | Sub-issue                                 |
+| WSJF/Role/DoD      | prioritization / mob role / gate      | description + `agent:*` labels + AC/DoD   |
+
+**The loop:** AI plans → AI asks clarifying questions → **HUMAN validates business context** → AI
+executes. Never skip the human validation step.
+
+## How to Structure Linear
+
+Build top-down:
+
+1. **Initiative** = the program. One per program.
+2. **Projects** = Units of Work. One coherent outcome each.
+3. **Milestones** = the three AI-DLC phases (Inception, Construction, Operations). Create all three
+   per project.
+4. **Issues** = Stories. Each carries the issue template below. Label with `bolt:N` and `agent:*`
+   (lead role).
+5. **Sub-issues** = Mob Elaboration tasks. Create during Inception, not before.
+6. **Dependencies** = `blocks` / `blockedBy` edges forming the dependency DAG.
+
+Program streams map to **sub-initiatives** where the Linear plan supports them; where it does not,
+encode the stream as **project priority** instead (highest-risk stream = Urgent/High).
+
+Use `linear-sop` for the exact MCP tool calls, label prerequisites, and evidence templates.
+
+## Issue Template
+
+Every issue description block contains:
+
+```text
+Header:      <ID> — <title>  [{{TICKET_PREFIX}}-XXX]
+WSJF:        <score>   MoSCoW: <Must|Should|Could|Won't>
+Finding:     <source refs, e.g. audit finding IDs>
+Phase:       <Inception | Construction | Operations>
+Bolt:        <bolt:N>
+Role:        <agent:* lead>
+AC:          - acceptance criterion (testable)
+DoD:         - merged to {{MAIN_BRANCH}}; relevant gate REAL and green; evidence in Linear;
+               no silent suppression
+Deps:        blocks: [...]   blockedBy: [...]
+Sub-issues:  (Mob Elaboration tasks, added during Inception)
+```
+
+## Dependency-Wiring Rules
+
+Wire `blocks` / `blockedBy` so the enforcement lands **before** the thing it enforces:
+
+- **Fix the gate before the fix it verifies.** Harden CI or un-mask a check before landing the fix
+  that check is supposed to catch.
+- **Rotate before scrub.** Rotate a leaked credential before scrubbing it from history.
+- **Capture before alert.** Error capture or health check blocks the alerter and the poller built on
+  top of it.
+- **Upgrades before re-baseline.** Framework and SDK upgrades block audit re-baselining, which blocks
+  the scheduled recurring audit.
+
+Dependency chains are usually rooted at CI hardening — one keystone issue tends to unblock a whole
+stream. Identify it and sequence its Bolt first.
+
+## Running a Bolt
+
+1. **Open and elaborate** every issue in the Bolt (Mob Elaboration: sub-issues, unknowns, questions).
+2. **Validate with the human** on all business, security, and policy decisions before Construction.
+3. **Construct** in dependency order on `{{TICKET_PREFIX}}-` branches with SAFe commits, rebase-first.
+4. **Verify gates are real** — a green check that still masks a failure is not an exit.
+5. **Post evidence** to Linear (dev/staging/done) per `linear-sop`.
+6. **Merge** — RTE prepares the PR; the human (HITL) merges. Exit = merged + real gates green +
+   evidence posted.
+
+## Human-Gate Checklist
+
+Route to the human, with options and a recommendation, whenever a decision is:
+
+- A **secret or credential** action (what to rotate, when, blast radius)
+- A **security policy**: CSP allow-list, auth behavior, headers
+- A **CI or branch-protection** decision: which checks become required
+- A **severity or risk policy**: dependency-audit thresholds, fix-vs-suppress budget
+- An **SOP exception** (e.g. a migration deviating from the documented process)
+- **Signing the Definition of Done**
+
+If a decision changes business, security, or risk posture, it is the human's — surface, recommend,
+stop.
+
+## Anti-Patterns (Do NOT use)
+
+```text
+Forcing an ambiguous epic into one Bolt    (run a spike instead — elaboration is the hard part)
+Creating sub-issues before Inception       (Mob Elaboration produces them, not the other way round)
+Bolts as calendar sprints                  (a Bolt exits on evidence, not on a date)
+Skipping human validation to move faster   (the loop is the method; without it this is just SAFe)
+Treating a green check as an exit          (verify the gate enforces, not that it merely passed)
+```
+
+## Authoritative References
+
+- **Methodology guide**: `/docs/guides/SAFE-AI-DLC-METHODOLOGY.md`
+- **Program template**: `/specs_templates/program_template.md`
+- **AI-DLC source**: <https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/>
+
+## Routes To
+
+- `linear-sop` — MCP tool calls, program structure, issue creation, evidence templates
+- `safe-workflow` — branch, commit, and PR conventions; HITL merge
+- `orchestration-patterns` — multi-agent swarm coordination for a Bolt
+- `pattern-discovery` — find existing code and doc patterns before constructing

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -88,11 +88,12 @@ Each skill follows this structure:
 
 Skills are **shared across all agents** (not Codex-specific). The same `.agents/skills/` directory is used by any tool that supports the convention.
 
-#### Available Skills (18)
+#### Available Skills (19)
 
 | Skill | Description |
 |-------|-------------|
 | `safe-workflow` | Branch naming, commits, PR workflow |
+| `safe-ai-dlc` | Program cadence: Units of Work, Bolts, human-in-the-loop gate |
 | `pattern-discovery` | Pattern library discovery |
 | `testing-patterns` | Unit, integration, E2E patterns |
 | `api-patterns` | REST API implementation patterns |

--- a/.cursor/rules/03-safe-ai-dlc.mdc
+++ b/.cursor/rules/03-safe-ai-dlc.mdc
@@ -75,6 +75,6 @@ Never guess these — surface options with a recommendation and stop:
 
 ## References
 
-- `/docs/guides/SAFE-AI-DLC-METHODOLOGY.md`
-- `/specs_templates/program_template.md`
+- `docs/guides/SAFE-AI-DLC-METHODOLOGY.md` -- Methodology guide (rationale, worked example)
+- `specs_templates/program_template.md` -- Program document scaffolding
 - AI-DLC source: <https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/>

--- a/.cursor/rules/03-safe-ai-dlc.mdc
+++ b/.cursor/rules/03-safe-ai-dlc.mdc
@@ -6,7 +6,7 @@ alwaysApply: false
 # SAFe x AI-DLC (Program Cadence)
 
 Use this rule when work spans **multiple issues and needs cadence** — turning an audit, epic, or
-initiative into an executable program. For a single isolated ticket, use `@01-git-workflow` instead.
+initiative into an executable program. For a single isolated ticket, use `.cursor/rules/01-git-workflow.mdc` instead.
 
 SAFe supplies the hierarchy and guardrails. AI-DLC supplies the cadence and the human checkpoint.
 The **sprint is replaced by the Bolt** — an hours-to-days swarm — because agent teams elaborate,
@@ -31,9 +31,10 @@ build, and verify far faster than a week-long sprint assumes.
 | Epic/value stream | Program stream                        | Sub-initiative, or project priority |
 | Feature           | Unit of Work                          | Project                             |
 | PI increment      | Bolt                                  | `bolt:N` label + target date        |
-| Phase gate        | Inception / Construction / Operations | Project Milestone                   |
+| Phase gate        | Inception / Construction / Operations | Project Milestone (3 per project)   |
 | Story/Enabler     | Story                                 | Issue                               |
 | Task              | Mob task                              | Sub-issue                           |
+| WSJF/Role/DoD     | prioritization / mob role / gate      | description + `agent:*` + AC/DoD    |
 
 ## Dependency-Wiring Rules
 

--- a/.cursor/rules/03-safe-ai-dlc.mdc
+++ b/.cursor/rules/03-safe-ai-dlc.mdc
@@ -1,0 +1,80 @@
+---
+description: "SAFe x AI-DLC fusion for running programs: Bolts replace sprints, Units of Work replace Features, Mob Elaboration, and the human-in-the-loop validation gate. Activate when planning or running multi-issue programs."
+alwaysApply: false
+---
+
+# SAFe x AI-DLC (Program Cadence)
+
+Use this rule when work spans **multiple issues and needs cadence** — turning an audit, epic, or
+initiative into an executable program. For a single isolated ticket, use `@01-git-workflow` instead.
+
+SAFe supplies the hierarchy and guardrails. AI-DLC supplies the cadence and the human checkpoint.
+The **sprint is replaced by the Bolt** — an hours-to-days swarm — because agent teams elaborate,
+build, and verify far faster than a week-long sprint assumes.
+
+## Vocabulary
+
+- **Bolt** — the unit of cadence. A short swarm (hours to a few days) with an entry gate, a handful
+  of issues, and a hard exit. Numbered `bolt:0`, `bolt:1`, and so on.
+- **Unit of Work** — an AI-DLC Feature. One coherent outcome. A project in the tracker.
+- **Mob Elaboration** — the Inception activity: read the issue, break it into sub-issues, list
+  unknowns, and ask clarifying questions **before writing any code**.
+- **Mob Construction** — the Construction activity: implement against the elaborated plan.
+- **The three phases** — Inception, Construction, Operations.
+- **The loop** — AI plans → AI asks → **human validates business context** → AI executes.
+
+## The Fusion Mapping
+
+| SAFe              | AI-DLC                                | Linear                              |
+| ----------------- | ------------------------------------- | ----------------------------------- |
+| Portfolio Epic    | The Program                           | Initiative                          |
+| Epic/value stream | Program stream                        | Sub-initiative, or project priority |
+| Feature           | Unit of Work                          | Project                             |
+| PI increment      | Bolt                                  | `bolt:N` label + target date        |
+| Phase gate        | Inception / Construction / Operations | Project Milestone                   |
+| Story/Enabler     | Story                                 | Issue                               |
+| Task              | Mob task                              | Sub-issue                           |
+
+## Dependency-Wiring Rules
+
+Wire `blocks` / `blockedBy` so the enforcement lands **before** the thing it enforces:
+
+- **Fix the gate before the fix it verifies**
+- **Rotate before scrub** (credentials)
+- **Capture before alert** (observability)
+- **Upgrades before re-baseline** (supply chain)
+
+Chains are usually rooted at CI hardening. Find that keystone and sequence its Bolt first.
+
+## Running a Bolt
+
+1. Open and elaborate every issue (Mob Elaboration)
+2. **Validate with the human** before Construction begins
+3. Construct in dependency order, rebase-first
+4. Verify the gates are **real** — a green check that masks a failure is not an exit
+5. Post evidence to the tracker
+6. RTE prepares the PR; the human (HITL) merges
+
+## Human-Gate Checklist
+
+Never guess these — surface options with a recommendation and stop:
+
+- Secret or credential actions
+- Security policy (CSP allow-list, auth behavior, headers)
+- CI or branch-protection decisions
+- Severity or risk policy, fix-vs-suppress budget
+- SOP exceptions
+- Signing the Definition of Done
+
+## Anti-Patterns
+
+- Forcing an ambiguous epic into one Bolt — run a **spike** instead
+- Creating sub-issues before Inception
+- Treating a Bolt as a calendar sprint (it exits on evidence, not a date)
+- Skipping human validation to move faster
+
+## References
+
+- `/docs/guides/SAFE-AI-DLC-METHODOLOGY.md`
+- `/specs_templates/program_template.md`
+- AI-DLC source: <https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/>

--- a/.cursor/rules/README.md
+++ b/.cursor/rules/README.md
@@ -22,6 +22,12 @@ Cursor uses `.cursor/rules/*.mdc` files with YAML frontmatter to provide context
 | `01-git-workflow.mdc`       | Branch naming, commit format, rebase-first, PR process |
 | `02-pattern-discovery.mdc`  | MANDATORY pattern discovery before implementing anything |
 
+### Methodology Rules (manual, use `@rule-name` to activate)
+
+| File | Purpose |
+| --- | --- |
+| `03-safe-ai-dlc.mdc` | SAFe x AI-DLC program cadence: Bolts, Units of Work, Mob Elaboration, human-gate checklist |
+
 ### Auto-Attached Tech Rules (active when matching files are open)
 
 | File                     | Globs                                      | Purpose                                |

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -26,11 +26,12 @@ All work requires verifiable evidence attached to Linear tickets:
 
 ## Available Skills
 
-Skills auto-load when context matches. All 17 skills:
+Skills auto-load when context matches. All 18 skills:
 
 | Skill | Trigger When |
 |-------|--------------|
 | `safe-workflow` | Starting work, commits, branches, PRs |
+| `safe-ai-dlc` | Planning or running a multi-issue program |
 | `pattern-discovery` | Before implementing features |
 | `rls-patterns` | Database operations, RLS policies |
 | `api-patterns` | Creating API endpoints |

--- a/.gemini/README.md
+++ b/.gemini/README.md
@@ -65,11 +65,12 @@ Skills provide contextual knowledge that auto-loads when relevant. View availabl
 gemini /skills
 ```
 
-### Included Skills (17)
+### Included Skills (18)
 
 | Skill | Description |
 |-------|-------------|
 | `safe-workflow` | SAFe development workflow, branch naming, commits |
+| `safe-ai-dlc` | Program cadence: Units of Work, Bolts, human-in-the-loop gate |
 | `pattern-discovery` | Pattern library discovery |
 | `rls-patterns` | Row Level Security patterns |
 | `api-patterns` | API route implementation |

--- a/.gemini/skills/README.md
+++ b/.gemini/skills/README.md
@@ -19,6 +19,7 @@ SAFe® is a registered trademark of Scaled Agile, Inc.
 | Skill | Purpose |
 |-------|---------|
 | safe-workflow | Branch naming, commits, PR workflow |
+| safe-ai-dlc | Program cadence: Units of Work, Bolts, human-in-the-loop gate |
 | release-patterns | PR creation, CI/CD validation |
 | pattern-discovery | Search patterns before implementing |
 | agent-coordination | Agent assignment, blockers |
@@ -35,7 +36,6 @@ SAFe® is a registered trademark of Scaled Agile, Inc.
 | stripe-patterns | Payment integration, webhooks |
 | deployment-sop | Deployment workflows |
 | confluence-docs | ADRs, runbooks, docs |
-| safe-ai-dlc | Program cadence: Units of Work, Bolts, human-in-the-loop gate |
 
 ## Claude Code-Specific Skills
 

--- a/.gemini/skills/README.md
+++ b/.gemini/skills/README.md
@@ -14,7 +14,7 @@ The skill system architecture and {{PROJECT_SHORT}} harness methodology are the 
 
 SAFe® is a registered trademark of Scaled Agile, Inc.
 
-## Skills Included (17)
+## Skills Included (18)
 
 | Skill | Purpose |
 |-------|---------|
@@ -35,6 +35,7 @@ SAFe® is a registered trademark of Scaled Agile, Inc.
 | stripe-patterns | Payment integration, webhooks |
 | deployment-sop | Deployment workflows |
 | confluence-docs | ADRs, runbooks, docs |
+| safe-ai-dlc | Program cadence: Units of Work, Bolts, human-in-the-loop gate |
 
 ## Claude Code-Specific Skills
 

--- a/.gemini/skills/linear-sop/README.md
+++ b/.gemini/skills/linear-sop/README.md
@@ -40,6 +40,7 @@ Linear ticket management best practices with evidence templates for dev/staging/
 
 - [spec-creation](../spec-creation/) - Spec templates
 - [safe-workflow](../safe-workflow/) - Workflow standards
+- [safe-ai-dlc](../safe-ai-dlc/) - Program structure: initiatives, Units of Work, Bolts
 
 ## Maintenance
 

--- a/.gemini/skills/linear-sop/SKILL.md
+++ b/.gemini/skills/linear-sop/SKILL.md
@@ -55,6 +55,63 @@ linear issue update {{TICKET_PREFIX}}-XXX --state "Done"
 linear issue comment {{TICKET_PREFIX}}-XXX "**Dev Evidence**\n\n..."
 ```
 
+## Program Structure
+
+For work that spans many issues, Linear has objects **above** the issue. Use them; do not flatten a
+program into a flat list of tickets.
+
+### The Hierarchy
+
+```text
+Initiative          the program (one per program)
+  └── Project       a Unit of Work — one coherent outcome
+       ├── Milestone    an AI-DLC phase: Inception, Construction, Operations
+       └── Issue        a Story
+            └── Sub-issue   a Mob Elaboration task (created during Inception, not before)
+```
+
+### Prerequisite: labels must already exist
+
+Program build-out assumes these label namespaces are **pre-created in the workspace**. Create them
+before building the program, not during:
+
+- `bolt:0` … `bolt:N` — which Bolt an issue belongs to
+- `agent:*` — the lead role (must match an actual agent role defined for the project)
+
+Labels are workspace-scoped in Linear — do not create team-scoped duplicates.
+
+### Streams
+
+Linear **sub-initiatives require an Enterprise plan**. If your workspace has it, model program
+streams as sub-initiatives under the initiative. If it does not, encode the stream as **project
+priority** instead — highest-risk stream gets Urgent/High, follow-up stream gets Medium.
+
+### Building the Program (Manual Process)
+
+```bash
+# Create the initiative
+# Linear Web UI: Initiatives → New initiative
+
+# Add a project (Unit of Work) to the initiative
+# Linear Web UI: Initiative → Add project
+
+# Add the three AI-DLC phase milestones to each project
+# Linear Web UI: Project → Milestones → New milestone
+
+# Wire dependencies between issues
+# Linear Web UI: Issue → Add relation → "Blocks" / "Blocked by"
+```
+
+Use `relatedTo` ("Related") for soft links that inform but do not block.
+
+**Wire so the enforcement lands before the thing it enforces** — see the `safe-ai-dlc` skill for the
+four dependency-wiring heuristics.
+
+### Re-parenting existing issues
+
+When a program absorbs tickets that already exist, **update them into the project — never recreate
+them**. Duplicates break traceability and split the evidence trail.
+
 ## Evidence Policy (MUST)
 
 Every issue requires evidence at each phase:

--- a/.gemini/skills/safe-ai-dlc/README.md
+++ b/.gemini/skills/safe-ai-dlc/README.md
@@ -35,10 +35,10 @@ Provides the Linear mapping, the issue template, four dependency-wiring heuristi
 
 ## Provider Compatibility
 
-| Provider    | Status                                          |
-| ----------- | ----------------------------------------------- |
-| Gemini CLI  | ✅ Native (program build-out is a manual process) |
-| Claude Code | ✅ Equivalent skill in `.claude/skills/`          |
+| Provider | Status |
+| --- | --- |
+| Gemini CLI | ✅ Native (program build-out is a manual process) |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Related Skills
 

--- a/.gemini/skills/safe-ai-dlc/README.md
+++ b/.gemini/skills/safe-ai-dlc/README.md
@@ -1,0 +1,58 @@
+# SAFe x AI-DLC
+
+![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-{{HARNESS_VERSION}}-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
+
+> Plan and run programs using the SAFe x AI-DLC fusion. Use when turning an audit, epic, or initiative into Linear structure, organizing work as Units of Work and Bolts, or running a Bolt swarm with a human-in-the-loop gate.
+
+## License
+
+**License:** MIT (see [/LICENSE](/LICENSE))
+**Copyright:** © 2026 J. Scott Graham ([@cheddarfox](https://github.com/cheddarfox)) / [ByBren, LLC](https://github.com/bybren-llc)
+**Attribution:** Required per [/NOTICE](/NOTICE)
+
+## Intellectual Property
+
+The skill system architecture and {{PROJECT_SHORT}} harness methodology are the intellectual property of J. Scott Graham and ByBren, LLC.
+
+SAFe® is a registered trademark of Scaled Agile, Inc.
+
+## Quick Start
+
+This skill activates automatically when you mention:
+
+- Turning an audit or initiative into a program
+- Bolts, Units of Work, or Mob Elaboration
+- Structuring work above the level of a single issue
+- Wiring a dependency DAG across issues
+
+## What This Skill Does
+
+Fuses SAFe structure with the AI-DLC delivery cadence. SAFe supplies the hierarchy, WSJF, role boundaries, and Definition of Done; AI-DLC supplies **Bolts** (hours-to-days swarms that replace sprints), **Units of Work**, **Mob Elaboration**, and the plan → clarify → validate → execute loop with a human checkpoint in the middle.
+
+Provides the Linear mapping, the issue template, four dependency-wiring heuristics, the six steps of running a Bolt, and the human-gate checklist.
+
+## Provider Compatibility
+
+| Provider    | Status                                          |
+| ----------- | ----------------------------------------------- |
+| Gemini CLI  | ✅ Native (program build-out is a manual process) |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/`          |
+
+## Related Skills
+
+- [linear-sop](../linear-sop/) - Ticket operations and evidence templates
+- [safe-workflow](../safe-workflow/) - Workflow standards
+- [orchestration-patterns](../orchestration-patterns/) - Multi-agent coordination
+
+## Maintenance
+
+| Field           | Value               |
+| --------------- | ------------------- |
+| Last Updated    | 2026-07-19          |
+| Harness Version | {{HARNESS_VERSION}} |
+
+---
+
+*Full implementation details in [SKILL.md](SKILL.md)*

--- a/.gemini/skills/safe-ai-dlc/SKILL.md
+++ b/.gemini/skills/safe-ai-dlc/SKILL.md
@@ -27,8 +27,7 @@ Do NOT use it for a single isolated ticket with no program context — use `safe
 ## The Fusion Model
 
 SAFe gives hierarchy, WSJF, roles, DoD, and dependencies. AI-DLC gives cadence (Bolts) and the
-human-in-the-loop. See the [methodology guide](/docs/guides/SAFE-AI-DLC-METHODOLOGY.md) for the full
-rationale.
+human-in-the-loop. See `docs/guides/SAFE-AI-DLC-METHODOLOGY.md` for the full rationale.
 
 | SAFe              | AI-DLC                                | Linear                                  |
 | ----------------- | ------------------------------------- | --------------------------------------- |
@@ -137,8 +136,8 @@ Treating a green check as an exit          (verify the gate enforces, not that i
 
 ## Reference
 
-- **Methodology guide**: `/docs/guides/SAFE-AI-DLC-METHODOLOGY.md`
-- **Program template**: `/specs_templates/program_template.md`
+- `docs/guides/SAFE-AI-DLC-METHODOLOGY.md` -- Methodology guide (rationale, worked example)
+- `specs_templates/program_template.md` -- Program document scaffolding
 - **AI-DLC source**: <https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/>
 - **Linear Documentation**: <https://linear.app/docs>
 

--- a/.gemini/skills/safe-ai-dlc/SKILL.md
+++ b/.gemini/skills/safe-ai-dlc/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: safe-ai-dlc
+description: Plan and run programs using the SAFe x AI-DLC fusion. Use when turning an audit, epic, or initiative into Linear structure (initiative, projects, milestones, issues, sub-issues), organizing work as Units of Work and Bolts, wiring a dependency DAG, or running a Bolt swarm with a human-in-the-loop gate.
+---
+
+# SAFe x AI-DLC Skill
+
+> **📋 TEMPLATE**: This skill uses `{{TICKET_PREFIX}}` and `{{MAIN_BRANCH}}` as placeholders.
+> Replace with your project's ticket prefix (e.g., `WOR`, `PROJ`) and base branch (e.g., `dev`, `main`).
+
+## Purpose
+
+Encode the SAFe x AI-DLC fusion so agents structure multi-issue programs consistently: SAFe supplies
+the hierarchy and guardrails, AI-DLC supplies the cadence and the human checkpoint. Sprints are
+replaced by **Bolts** because agent teams elaborate, build, and verify in hours, not weeks.
+
+## When This Skill Applies
+
+- Turning an audit, epic, or initiative into an executable program
+- Structuring work in Linear as initiative, projects, milestones, issues, and sub-issues
+- Breaking an initiative into Units of Work and sequencing them into Bolts
+- Wiring dependencies so gates land before the fixes they verify
+- Running a Bolt: elaborate, validate with the human, construct, verify gates are real, evidence, merge
+
+Do NOT use it for a single isolated ticket with no program context — use `safe-workflow` for that.
+
+## The Fusion Model
+
+SAFe gives hierarchy, WSJF, roles, DoD, and dependencies. AI-DLC gives cadence (Bolts) and the
+human-in-the-loop. See the [methodology guide](/docs/guides/SAFE-AI-DLC-METHODOLOGY.md) for the full
+rationale.
+
+| SAFe              | AI-DLC                                | Linear                                  |
+| ----------------- | ------------------------------------- | --------------------------------------- |
+| Portfolio Epic    | The Program                           | Initiative                              |
+| Epic/value stream | Program stream                        | Sub-initiative, or project priority     |
+| Feature           | Unit of Work                          | Project                                 |
+| PI increment      | Bolt                                  | `bolt:N` label + target date            |
+| Phase gate        | Inception / Construction / Operations | Project Milestone (3 per project)       |
+| Story/Enabler     | Story                                 | Issue                                   |
+| Task              | Mob task                              | Sub-issue                               |
+| WSJF/Role/DoD     | prioritization / mob role / gate      | description + `agent:*` labels + AC/DoD |
+
+**The loop:** AI plans → AI asks clarifying questions → **HUMAN validates business context** → AI
+executes. Never skip the human validation step.
+
+## Building the Program (Manual Process)
+
+Since Gemini CLI does not have native Linear integration, build the program through the Linear web UI
+(or the Linear CLI if installed). Build top-down:
+
+1. **Initiative** = the program. One per program.
+   `Linear web UI → Initiatives → New initiative`
+2. **Projects** = Units of Work. One coherent outcome each.
+   `Initiative → Add project`
+3. **Milestones** = the three AI-DLC phases (Inception, Construction, Operations). Create all three
+   per project.
+   `Project → Milestones → New milestone`
+4. **Issues** = Stories. Each carries the issue template below. Label with `bolt:N` and `agent:*`
+   (lead role). Labels must already exist in the workspace.
+5. **Sub-issues** = Mob Elaboration tasks. Create during Inception, not before.
+   `Issue → Add sub-issue`
+6. **Dependencies** = `blocks` / `blockedBy` edges forming the dependency DAG.
+   `Issue → Add relation → Blocks / Blocked by`
+
+Program streams map to **sub-initiatives** where the Linear plan supports them; where it does not,
+encode the stream as **project priority** instead (highest-risk stream = Urgent/High).
+
+Use `linear-sop` for ticket operations and evidence templates.
+
+## Issue Template
+
+Every issue description block contains:
+
+```text
+Header:      <ID> — <title>  [{{TICKET_PREFIX}}-XXX]
+WSJF:        <score>   MoSCoW: <Must|Should|Could|Won't>
+Finding:     <source refs, e.g. audit finding IDs>
+Phase:       <Inception | Construction | Operations>
+Bolt:        <bolt:N>
+Role:        <agent:* lead>
+AC:          - acceptance criterion (testable)
+DoD:         - merged to {{MAIN_BRANCH}}; relevant gate REAL and green; evidence in Linear;
+               no silent suppression
+Deps:        blocks: [...]   blockedBy: [...]
+Sub-issues:  (Mob Elaboration tasks, added during Inception)
+```
+
+## Dependency-Wiring Rules
+
+Wire `blocks` / `blockedBy` so the enforcement lands **before** the thing it enforces:
+
+- **Fix the gate before the fix it verifies.** Harden CI or un-mask a check before landing the fix
+  that check is supposed to catch.
+- **Rotate before scrub.** Rotate a leaked credential before scrubbing it from history.
+- **Capture before alert.** Error capture or health check blocks the alerter and the poller built on
+  top of it.
+- **Upgrades before re-baseline.** Framework and SDK upgrades block audit re-baselining, which blocks
+  the scheduled recurring audit.
+
+Dependency chains are usually rooted at CI hardening — one keystone issue tends to unblock a whole
+stream. Identify it and sequence its Bolt first.
+
+## Running a Bolt
+
+1. **Open and elaborate** every issue in the Bolt (Mob Elaboration: sub-issues, unknowns, questions).
+2. **Validate with the human** on all business, security, and policy decisions before Construction.
+3. **Construct** in dependency order on `{{TICKET_PREFIX}}-` branches with SAFe commits, rebase-first.
+4. **Verify gates are real** — a green check that still masks a failure is not an exit.
+5. **Post evidence** to Linear (dev/staging/done) per `linear-sop`.
+6. **Merge** — RTE prepares the PR; the human (HITL) merges. Exit = merged + real gates green +
+   evidence posted.
+
+## Human-Gate Checklist
+
+Route to the human, with options and a recommendation, whenever a decision is:
+
+- A **secret or credential** action (what to rotate, when, blast radius)
+- A **security policy**: CSP allow-list, auth behavior, headers
+- A **CI or branch-protection** decision: which checks become required
+- A **severity or risk policy**: dependency-audit thresholds, fix-vs-suppress budget
+- An **SOP exception** (e.g. a migration deviating from the documented process)
+- **Signing the Definition of Done**
+
+If a decision changes business, security, or risk posture, it is the human's — surface, recommend,
+stop.
+
+## Anti-Patterns (Do NOT use)
+
+```text
+Forcing an ambiguous epic into one Bolt    (run a spike instead — elaboration is the hard part)
+Creating sub-issues before Inception       (Mob Elaboration produces them, not the other way round)
+Bolts as calendar sprints                  (a Bolt exits on evidence, not on a date)
+Skipping human validation to move faster   (the loop is the method; without it this is just SAFe)
+Treating a green check as an exit          (verify the gate enforces, not that it merely passed)
+```
+
+## Reference
+
+- **Methodology guide**: `/docs/guides/SAFE-AI-DLC-METHODOLOGY.md`
+- **Program template**: `/specs_templates/program_template.md`
+- **AI-DLC source**: <https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/>
+- **Linear Documentation**: <https://linear.app/docs>
+
+## Routes To
+
+- `linear-sop` — Linear operations, program structure, evidence templates
+- `safe-workflow` — branch, commit, and PR conventions; HITL merge
+- `orchestration-patterns` — multi-agent swarm coordination for a Bolt
+- `pattern-discovery` — find existing code and doc patterns before constructing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ Skills are loaded progressively—metadata at startup, full content when context
 | Skill                    | Trigger                | Purpose                                     |
 | ------------------------ | ---------------------- | ------------------------------------------- |
 | `safe-workflow`          | Commits, branches, PRs | SAFe format, rebase-first workflow          |
+| `safe-ai-dlc`            | Multi-issue programs   | Bolts, Units of Work, HITL gate             |
 | `pattern-discovery`      | Before writing code    | Pattern-first development (MANDATORY)       |
 | `rls-patterns`           | Database operations    | RLS context helpers (withUserContext, etc.) |
 | `frontend-patterns`      | UI work                | Clerk, shadcn, Next.js patterns             |

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@
     <img src="https://img.shields.io/badge/agents-11%20SAFe%20roles-red?style=flat-square" alt="Agents">
   </a>
   <a href=".claude/skills/">
-    <img src="https://img.shields.io/badge/skills-18%20model--invoked-purple?style=flat-square" alt="Skills">
+    <img src="https://img.shields.io/badge/skills-19%20model--invoked-purple?style=flat-square" alt="Skills">
   </a>
   <a href=".claude/commands/">
     <img src="https://img.shields.io/badge/commands-24%20workflows-orange?style=flat-square" alt="Commands">
   </a>
   <a href=".cursor/rules/">
-    <img src="https://img.shields.io/badge/cursor%20rules-16-00D084?style=flat-square" alt="Cursor Rules">
+    <img src="https://img.shields.io/badge/cursor%20rules-17-00D084?style=flat-square" alt="Cursor Rules">
   </a>
 </p>
 
@@ -203,6 +203,7 @@ bash scripts/setup-template.sh                # Re-apply your placeholders
 **Adopting into an existing repo?** See the [Workspace Adoption Guide](docs/guides/WORKSPACE-ADOPTION-GUIDE.md).
 **Upgrading from a previous version?** See [Keeping the Harness Updated](docs/guides/WORKSPACE-ADOPTION-GUIDE.md#keeping-the-harness-updated).
 **Syncing your fork with upstream?** See the [Harness Sync Guide](docs/HARNESS_SYNC_GUIDE.md).
+**Planning a multi-issue program?** See the [SAFe x AI-DLC Methodology](docs/guides/SAFE-AI-DLC-METHODOLOGY.md).
 
 ### Key Commands
 
@@ -354,7 +355,7 @@ This harness directly implements patterns from Anthropic's engineering papers:
 | ----------------------------------------------------------------------------------------------------------- | -------------------------- |
 | [Building Effective Agents](https://www.anthropic.com/engineering/building-effective-agents)                | 11-agent team structure    |
 | [Effective Harnesses](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)    | Three-layer architecture   |
-| [Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) | 18 model-invoked skills    |
+| [Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) | 19 model-invoked skills    |
 | [Skills Announcement](https://www.anthropic.com/news/skills)                                                | Skills 2.0 frontmatter, trigger patterns |
 | [Code Execution with MCP](https://www.anthropic.com/engineering/code-execution-with-mcp)                    | Tool restrictions per role |
 
@@ -380,12 +381,49 @@ This harness maps SAFe roles to AI agents:
 ### SAFe Concepts Implemented
 
 - **Epic → Feature → Story → Enabler** hierarchy in specs
-- **Sprint cycles** with velocity tracking
+- **Sprint cycles** with velocity tracking (or **Bolts** — see below)
 - **Evidence-based delivery** with Linear integration
 - **Specs-driven workflow** - BSA plans, developers execute
 
 
 </details>
+
+---
+
+## Program Cadence: SAFe x AI-DLC
+
+SAFe gives this harness its structure. But SAFe's _cadence_ assumes human squads on week-long
+sprints, and agent teams do not move at that speed — a team of specialized agents can elaborate,
+build, and verify a unit of work in hours.
+
+So the harness also ships the **SAFe x AI-DLC fusion**: SAFe keeps the hierarchy, WSJF, role
+boundaries, and Definition of Done; [AWS's AI-Driven Development Life Cycle](https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/)
+supplies the cadence and the human checkpoint. **The sprint is replaced by the Bolt.**
+
+| Concept | What it replaces | Definition |
+| --- | --- | --- |
+| **Bolt** | The sprint | An hours-to-days swarm with an entry gate and a hard exit. Exits on evidence, not a date. |
+| **Unit of Work** | The Feature | One coherent outcome. A project in the tracker. |
+| **Mob Elaboration** | Sprint planning | Decompose, list unknowns, ask questions — **before** writing any code. |
+| **The loop** | The stand-up | AI plans → AI asks → **human validates business context** → AI executes. |
+
+The human validation step is not optional. Agents own the build; humans own the judgment — secrets,
+security policy, branch protection, risk thresholds, and signing the Definition of Done always route
+to a human with options and a recommendation.
+
+### Using It
+
+| Resource | Purpose |
+| --- | --- |
+| [Methodology guide](docs/guides/SAFE-AI-DLC-METHODOLOGY.md) | Read this first — vocabulary, worked example, when **not** to use a Bolt |
+| `safe-ai-dlc` skill | The method encoded for agents (all four providers) |
+| [Program template](specs_templates/program_template.md) | Scaffolding for a new program document |
+| `linear-sop` skill | Program structure: initiative → project → milestone → issue |
+
+Use it when work spans **many issues and needs cadence** — turning an audit, epic, or initiative into
+an executable program. For a single ticket, the standard `safe-workflow` path is correct. And if the
+problem space is still unclear, run a **spike** instead: forcing an ambiguous epic into one Bolt just
+relocates the ambiguity into the code.
 
 ---
 
@@ -1265,14 +1303,14 @@ See [Agent Workflow SOP v1.4](docs/sop/AGENT_WORKFLOW_SOP.md) for complete detai
 ```text
 .claude/                 # Claude Code harness (primary provider)
 ├── commands/            # 24 slash commands for workflow automation
-├── skills/              # 18 model-invoked skills for domain expertise
+├── skills/              # 19 model-invoked skills for domain expertise
 ├── agents/              # 11 SAFe agent profiles
 ├── team-config.json     # Agent Teams settings (optional, experimental)
 └── SETUP.md             # Installation and customization guide
 
 .gemini/                 # Gemini CLI harness (secondary provider)
 ├── commands/            # 30 TOML commands (namespaced: /workflow:*, /local:*, /remote:*, /media:*)
-├── skills/              # 17 model-invoked skills (team-coordination is Claude-only)
+├── skills/              # 18 model-invoked skills (team-coordination is Claude-only)
 ├── settings.json        # Configuration (model, hooks, policy, security)
 ├── GEMINI.md            # System instructions
 └── README.md            # Gemini-specific setup guide
@@ -1284,12 +1322,13 @@ See [Agent Workflow SOP v1.4](docs/sop/AGENT_WORKFLOW_SOP.md) for complete detai
 .cursor/                 # Cursor IDE harness (glob-based .mdc rules, background agents)
 └── rules/               # .mdc rule files with YAML frontmatter activation
     ├── 00-02            # Always-apply core rules (SAFe, git, patterns)
+    ├── 03               # SAFe x AI-DLC program cadence (manual activation)
     ├── 10-13            # Auto-attached tech rules (Python, React, SQL, tests)
     ├── 20-23            # Agent-role rules (Architect, Backend, QAS, Security)
     └── 30-31            # Background agents and MCP integration
 
 .agents/                 # Shared agent skills (discovered by Codex and other agents)
-└── skills/              # 18 cross-provider skills (api-patterns, safe-workflow, etc.)
+└── skills/              # 19 cross-provider skills (api-patterns, safe-workflow, etc.)
 
 dark-factory/            # tmux Agent Teams infrastructure (optional)
 ├── scripts/             # factory-setup, start, stop, status, attach
@@ -1297,8 +1336,11 @@ dark-factory/            # tmux Agent Teams infrastructure (optional)
 └── docs/                # Dark Factory guide, Cursor SSH, merge queue policy
 
 docs/                    # Additional documentation
+├── guides/              # Methodology and adoption guides (incl. SAFe x AI-DLC)
 ├── whitepapers/         # Harness architecture and philosophy
 └── onboarding/          # Getting started guides
+
+specs_templates/         # Spec, planning, PI planning, and program templates
 ```
 
 ---

--- a/docs/guides/SAFE-AI-DLC-METHODOLOGY.md
+++ b/docs/guides/SAFE-AI-DLC-METHODOLOGY.md
@@ -41,7 +41,7 @@ The result is not "SAFe but faster." It is SAFe with its clock replaced.
 | SAFe              | AI-DLC                                | Linear                                  |
 | ----------------- | ------------------------------------- | --------------------------------------- |
 | Portfolio Epic    | The Program                           | Initiative                              |
-| Epic/value stream | Program stream                        | Sub-initiative, or project priority      |
+| Epic/value stream | Program stream                        | Sub-initiative, or project priority     |
 | Feature           | Unit of Work                          | Project                                 |
 | PI increment      | Bolt (hours to days)                  | `bolt:N` label + target date            |
 | Phase gate        | Inception / Construction / Operations | Project Milestone                       |

--- a/docs/guides/SAFE-AI-DLC-METHODOLOGY.md
+++ b/docs/guides/SAFE-AI-DLC-METHODOLOGY.md
@@ -1,0 +1,142 @@
+# SAFe x AI-DLC Methodology
+
+**Purpose**: Define the fusion of SAFe structure with the AI-Driven Development Life Cycle, and explain how to plan and run programs at agent speed.
+
+**Audience**: Anyone contributing to a project using this harness -- human or agent. Read this if you have only ever worked the sprint model.
+
+**Core Belief**: SAFe keeps the structure and the guardrails. AI-DLC supplies the speed and the human checkpoint. The sprint is replaced by the **Bolt**.
+
+---
+
+## Why Fuse Them
+
+SAFe is the base. It gives us the hierarchy (initiative to project to issue), WSJF prioritization, clear role boundaries, a Definition of Done, and disciplined dependencies. That machinery works, and this harness already ships it.
+
+But SAFe's *cadence* assumes human squads on week-long sprints. Agent teams do not move at that speed. A team of specialized agents can elaborate, build, and verify a unit of work in hours. Planning that work into two-week increments wastes most of the capability and hides progress behind ceremony.
+
+AWS's [AI-Driven Development Life Cycle](https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/) (AI-DLC) is built for exactly this: a tight plan, clarify, validate, execute loop with a human in the middle. So we fuse the two. SAFe supplies structure and guardrails; AI-DLC supplies cadence and the human checkpoint.
+
+The result is not "SAFe but faster." It is SAFe with its clock replaced.
+
+---
+
+## The Vocabulary
+
+**Bolt** -- the unit of cadence, replacing the sprint. A short swarm (hours to a few days) with an entry gate, a handful of issues, and a hard exit. Named and numbered (`bolt:0`, `bolt:1`, and so on). A Bolt exits on **evidence**, not on a date.
+
+**Unit of Work** -- an AI-DLC Feature. In the tracker it is a Project. It is one coherent outcome, not a grab-bag of related tickets.
+
+**Mob Elaboration** -- the Inception activity. The AI reads the issue, breaks it into sub-issues (mob tasks), lists unknowns, and asks clarifying questions **before writing any code**.
+
+**Mob Construction** -- the Construction activity. The AI implements against the elaborated plan.
+
+**The three AI-DLC phases** -- every project moves through **Inception** (understand and decompose), **Construction** (build), and **Operations** (deploy and run). Model them as three milestones per project.
+
+**The loop** -- AI plans, AI asks clarifying questions, the **human validates business context**, then AI executes. This is the heartbeat of the method. The human validation step is not optional.
+
+---
+
+## The Fusion Mapping
+
+| SAFe              | AI-DLC                                | Linear                                  |
+| ----------------- | ------------------------------------- | --------------------------------------- |
+| Portfolio Epic    | The Program                           | Initiative                              |
+| Epic/value stream | Program stream                        | Sub-initiative, or project priority      |
+| Feature           | Unit of Work                          | Project                                 |
+| PI increment      | Bolt (hours to days)                  | `bolt:N` label + target date            |
+| Phase gate        | Inception / Construction / Operations | Project Milestone                       |
+| Story/Enabler     | Story                                 | Issue                                   |
+| Task              | Mob task                              | Sub-issue                               |
+| WSJF/Role/DoD     | prioritization / mob role / gate      | description + `agent:*` labels + AC/DoD |
+
+Two notes on the mapping:
+
+- **Bolts are labels, not sprint cycles.** Bolts run hours to days and cut across projects; tracker cycles floor at a week and are team-wide. A `bolt:N` label plus a target date models the cadence correctly.
+- **Program streams** map to sub-initiatives where your tracker plan supports them. Where it does not, encode the stream as **project priority** instead -- the highest-risk stream gets Urgent/High.
+
+---
+
+## How to Run a Bolt
+
+1. **Open and elaborate.** The lead role opens each issue in the Bolt and runs Mob Elaboration: decompose into sub-issues, list unknowns, draft clarifying questions.
+2. **Validate with the human.** Bring the questions and any business, security, or policy decision to the human. Do not guess. Construction does not start until the context is validated.
+3. **Construct.** Mob Construction: build against the elaborated plan, on a ticket branch, with SAFe commits, rebase-first.
+4. **Verify the gates are real.** Run the actual checks and confirm they enforce. A green check that still masks a failure does not count.
+5. **Demo and post evidence.** Show the outcome; post dev/staging/done evidence to the issue.
+6. **Merge.** The RTE prepares the PR; the human (HITL) merges.
+
+A Bolt exits only when its issues are **merged**, its **gates are real and green**, and **evidence is posted**. Nothing else is an exit.
+
+---
+
+## The Human-Gate Principle
+
+Humans own business context; agents own the build.
+
+An agent must **never guess** a business, security, or policy decision. It surfaces options with a recommendation and routes the choice to the human. Decisions that always go to the human:
+
+- Which secrets to rotate, when, and the blast radius
+- Security policy: CSP allow-list, auth behavior, headers
+- Which CI checks become required, and branch-protection changes
+- Dependency severity policy and the fix-versus-suppress budget
+- Any exception to a documented SOP
+- Signing the Definition of Done
+
+When in doubt, ask. A two-minute question beats an hour of wrong construction.
+
+---
+
+## Worked Example: A Gate-Integrity Bolt
+
+The clearest illustration is a Bolt whose whole job is to make the project's quality gates mean something. Suppose an audit found three defects: the lint rule skips the directory that most needs it, CI swallows failures behind `|| echo`, and the type check runs against a weakened config so it never blocks.
+
+1. **Elaborate.** The architect opens all three issues. Mob Elaboration surfaces one real unknown: clearing the backlog of type errors could take many small fixes or a few blanket suppressions.
+2. **Validate with the human.** That is a budget decision, not a code decision, so it routes to the human -- how many suppressions are acceptable versus real fixes? Construction on that issue waits for the answer.
+3. **Construct in dependency order.** Shrink the lint ignores first, so the rule watches the right files. Then remove the CI masking, so failures actually surface. Only then make the type check block -- it can only meaningfully block once CI has stopped swallowing its result.
+4. **Verify real.** Seed a type error and a lint violation into a scratch branch and confirm CI **fails**. That is proof the gate enforces rather than decorates.
+5. **Evidence and merge.** Post the failing-then-passing CI runs to each issue; the RTE prepares the PRs; the human merges.
+
+Only now is the Bolt complete -- and only now can later Bolts trust CI to verify their own work. This ordering is the whole point: **fix the gate before the fix it verifies.**
+
+---
+
+## Dependency-Wiring Rules
+
+Wire `blocks` and `blockedBy` so the enforcement lands **before** the thing it enforces:
+
+- **Fix the gate before the fix it verifies.** Harden CI or un-mask a check before landing the fix that check is supposed to catch.
+- **Rotate before scrub.** Rotate a leaked credential before scrubbing it from history.
+- **Capture before alert.** Error capture or a health check blocks the alerter built on top of it.
+- **Upgrades before re-baseline.** Framework upgrades block audit re-baselining, which blocks the scheduled recurring scan.
+
+Dependency chains are usually rooted at CI hardening. One keystone issue tends to unblock a whole stream -- identify it and sequence its Bolt first.
+
+---
+
+## When NOT to Use a Bolt
+
+A Bolt is for work that can be elaborated and built inside a few days. It is the wrong tool when the work is genuinely large or uncertain -- an unclear problem space, a cross-cutting redesign, or a decision that needs research before it can even be decomposed.
+
+For that, run a **spike**: a time-boxed investigation that produces a plan, not shippable code. Or plan a full increment across several Bolts.
+
+Forcing an ambiguous epic into a single Bolt just relocates the ambiguity into the code. Elaborate first; **if elaboration itself is the hard part, that is a spike.**
+
+---
+
+## Related Reading
+
+- [Program Template](../../specs_templates/program_template.md) - Scaffolding for a new program document
+- [Round Table Philosophy](./ROUND-TABLE-PHILOSOPHY.md) - The collaboration model underneath the method
+- [Agent Workflow SOP](../sop/AGENT_WORKFLOW_SOP.md) - Workflow methods and exit states
+- [Agent Team Guide](./AGENT_TEAM_GUIDE.md) - Agent team structure and SAFe integration
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) - Git workflow and commit standards
+- Skills: `safe-ai-dlc` (this method, encoded for agents), `linear-sop`, `safe-workflow`, `orchestration-patterns`
+
+**External source**: [AI-Driven Development Life Cycle](https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/) (AWS DevOps Blog)
+
+---
+
+**Questions?**
+
+- GitHub Discussions: {{GITHUB_REPO_URL}}/discussions
+- Email: {{AUTHOR_EMAIL}}

--- a/docs/guides/SAFE-AI-DLC-METHODOLOGY.md
+++ b/docs/guides/SAFE-AI-DLC-METHODOLOGY.md
@@ -43,8 +43,8 @@ The result is not "SAFe but faster." It is SAFe with its clock replaced.
 | Portfolio Epic    | The Program                           | Initiative                              |
 | Epic/value stream | Program stream                        | Sub-initiative, or project priority     |
 | Feature           | Unit of Work                          | Project                                 |
-| PI increment      | Bolt (hours to days)                  | `bolt:N` label + target date            |
-| Phase gate        | Inception / Construction / Operations | Project Milestone                       |
+| PI increment      | Bolt                                  | `bolt:N` label + target date            |
+| Phase gate        | Inception / Construction / Operations | Project Milestone (3 per project)       |
 | Story/Enabler     | Story                                 | Issue                                   |
 | Task              | Mob task                              | Sub-issue                               |
 | WSJF/Role/DoD     | prioritization / mob role / gate      | description + `agent:*` labels + AC/DoD |

--- a/docs/guides/WORKSPACE-ADOPTION-GUIDE.md
+++ b/docs/guides/WORKSPACE-ADOPTION-GUIDE.md
@@ -112,7 +112,7 @@ grep -c '{{' CLAUDE.md AGENTS.md CONTRIBUTING.md .claude/team-config.json
 
 # Confirm harness structure
 ls .claude/agents/ | wc -l  # 11 agents
-ls .claude/skills/ | wc -l  # 18 skills
+ls .claude/skills/ | wc -l  # 19 skills
 ls .claude/commands/ | wc -l  # 23+ commands
 ```
 

--- a/docs/whitepapers/ANTHROPIC-RESEARCH-ALIGNMENT.md
+++ b/docs/whitepapers/ANTHROPIC-RESEARCH-ALIGNMENT.md
@@ -233,7 +233,7 @@ Skills activate based on context triggers, providing just-in-time expertise:
 - `safe-workflow` activates when making commits, branches, or PRs
 - `pattern-discovery` activates before writing any code
 
-This implements the separation of concerns principle. The agent does not carry all 18 skills in active context simultaneously. Skills surface when relevant, keeping the active context focused and performant.
+This implements the separation of concerns principle. The agent does not carry all 19 skills in active context simultaneously. Skills surface when relevant, keeping the active context focused and performant.
 
 **Specs (Session-Level Context)**
 

--- a/docs/whitepapers/CLAUDE-CODE-HARNESS-KT-META-PROMPT.md
+++ b/docs/whitepapers/CLAUDE-CODE-HARNESS-KT-META-PROMPT.md
@@ -455,7 +455,7 @@ Check PR #324 or subsequent PRs for full diff and review discussion.
 ├── .claude/
 │   ├── settings.json          # Hooks configuration
 │   ├── commands/              # 24 slash commands
-│   ├── skills/                # 18 model-invoked skills
+│   ├── skills/                # 19 model-invoked skills
 │   └── agents/                # 12 agent profiles
 ├── AGENTS.md                  # Quick reference
 ├── CONTRIBUTING.md            # Workflow documentation

--- a/docs/whitepapers/README.md
+++ b/docs/whitepapers/README.md
@@ -12,7 +12,7 @@ The complete technical documentation of the three-layer harness architecture:
 
 - Background and motivation
 - Three-layer architecture (Hooks → Commands → Skills)
-- All 18 skills with implementation details
+- All 19 skills with implementation details
 - All 24 slash commands organized by category
 - Phase 0-3 completion history
 - SAFe role expansion vision

--- a/specs_templates/README.md
+++ b/specs_templates/README.md
@@ -34,6 +34,20 @@ defines phase gate criteria. Includes 10 sections covering:
 A companion spreadsheet template (`pi_planning_template.xlsx`) is also provided
 for teams that prefer tabular formats. Keep one authoritative source.
 
+### `program_template.md`
+
+Used to define a **SAFe x AI-DLC program** — an initiative decomposed into Units of Work and
+sequenced into Bolts (hours-to-days swarms that replace sprints). Provides scaffolding for:
+
+- Units of Work table (project, outcome, issues, bolt, lead role)
+- Bolt timeline with mandatory entry and exit criteria
+- Mermaid dependency DAG and critical path
+- AI-DLC phase index (Inception / Construction / Operations)
+- RACI, the four-clause Definition of Done, and the human-gates checklist
+
+Use this when the work spans many issues and needs cadence. For a single unit of work, use
+`spec_template.md`. Method reference: [SAFe x AI-DLC Methodology](../docs/guides/SAFE-AI-DLC-METHODOLOGY.md).
+
 ### `spec_template.md`
 
 The master template for a single unit of work (typically a Linear User Story). The BSA agent copies this template to create a new `{{TICKET_PREFIX}}-XXX-feature-name-spec.md` file for each task.

--- a/specs_templates/program_template.md
+++ b/specs_templates/program_template.md
@@ -7,7 +7,7 @@
 | Field            | Value                                    |
 | ---------------- | ---------------------------------------- |
 | Initiative       | [{{TICKET_PREFIX}}-XXX / initiative URL] |
-| Source           | [audit, epic, or incident that triggered this] |
+| Source           | [audit or epic that triggered this]      |
 | Method           | SAFe x AI-DLC                            |
 | Owner (HITL)     | [role or name]                           |
 | Date             | [YYYY-MM-DD]                             |

--- a/specs_templates/program_template.md
+++ b/specs_templates/program_template.md
@@ -1,0 +1,152 @@
+# Program: [Program Name]
+
+> Scaffolding for a **SAFe x AI-DLC program** -- an initiative decomposed into Units of Work and
+> sequenced into Bolts. Replace every bracketed placeholder. Delete guidance blockquotes before
+> committing. Method reference: [SAFe x AI-DLC Methodology](../docs/guides/SAFE-AI-DLC-METHODOLOGY.md).
+
+| Field            | Value                                    |
+| ---------------- | ---------------------------------------- |
+| Initiative       | [{{TICKET_PREFIX}}-XXX / initiative URL] |
+| Source           | [audit, epic, or incident that triggered this] |
+| Method           | SAFe x AI-DLC                            |
+| Owner (HITL)     | [role or name]                           |
+| Date             | [YYYY-MM-DD]                             |
+| Status           | [Proposed / Active / Complete]           |
+
+---
+
+## Why This Exists
+
+> One or two paragraphs. State the problem in terms a reader outside the team would understand, and
+> name the single finding that justifies the whole program. Be concrete -- "a green CI run currently
+> means nothing" beats "quality needs improvement."
+
+[Problem statement.]
+
+**Program outcome**: [The one sentence that describes done.]
+
+---
+
+## Units of Work
+
+> Each project is one coherent outcome, not a grab-bag. Lead role must be an existing `agent:*` label.
+
+| Project | Outcome | Issues | Bolt | Lead role |
+| ------- | ------- | ------ | ---- | --------- |
+| P1 [Name] | [What is true when this is done] | [IDs] | `bolt:N` | `agent:*` |
+| P2 [Name] | | | | |
+| P3 [Name] | | | | |
+
+**Streams**: [If the tracker plan supports sub-initiatives, name them. Otherwise state how project
+priority encodes the streams -- e.g. Urgent/High = highest-risk stream, Medium = follow-up.]
+
+---
+
+## Issues
+
+> One row per issue. WSJF drives ordering within a Bolt; MoSCoW records negotiability.
+
+| ID | Ticket | Title | Project | Bolt | Phase | WSJF | MoSCoW | Status |
+| -- | ------ | ----- | ------- | ---- | ----- | ---- | ------ | ------ |
+| [ID] | {{TICKET_PREFIX}}-XXX | | | `bolt:N` | Inception | | Must | |
+
+---
+
+## Bolt Timeline
+
+> A Bolt exits on **evidence**, not on a date. Entry and exit criteria are mandatory -- a Bolt with
+> vague exit criteria will not close cleanly.
+
+| Bolt | Name | Duration | Issues (in order) | Entry criteria | Exit criteria |
+| ---- | ---- | -------- | ----------------- | -------------- | ------------- |
+| 0 | [Containment] | Hours | | [What must be true to start] | [What proves it is done] |
+| 1 | [Name] | 2-3 days | | Bolt 0 complete | |
+| 2 | [Name] | 2-3 days | | | |
+
+### The Mob Model
+
+A Bolt is a short swarm, not a solo assignment. The lead role opens each issue, runs Mob Elaboration
+into sub-issues, and **pauses for the human to validate business context** before Mob Construction
+begins. A Bolt exits only when its issues are **merged to `{{MAIN_BRANCH}}`**, the **relevant gates
+are real and green**, and **evidence is posted to the tracker**. A green check that still masks a
+failure is not an exit.
+
+---
+
+## Dependency DAG
+
+> Wire so the enforcement lands before the thing it enforces: fix the gate before the fix it
+> verifies; rotate before scrub; capture before alert; upgrades before re-baseline.
+
+```mermaid
+graph LR
+  A[ID-01 keystone] --> B[ID-02]
+  A --> C[ID-03]
+  B --> D[ID-04]
+```
+
+**Critical path**: [Name the keystone issue and explain why it gates the rest.]
+
+**Soft links** (`relatedTo`, not blocking): [list]
+
+---
+
+## AI-DLC Phase Index
+
+> Which issues need real elaboration before anyone writes code, and which are ready to build.
+
+- **Inception-heavy** (unknowns to resolve, decisions to route): [IDs]
+- **Construction-ready** (elaborated, unblocked): [IDs]
+- **Operations** (deploy, schedule, run): [IDs]
+
+> An issue may appear in two phases -- e.g. a policy decision in Inception and the scheduled job that
+> enforces it in Operations. Note those explicitly.
+
+---
+
+## Roles and RACI
+
+| Concern                     | Responsible  | Accountable | Consulted   | Informed |
+| --------------------------- | ------------ | ----------- | ----------- | -------- |
+| [Unit of Work]              | `agent:*`    | `agent:rte` | [role]      | Team     |
+| Business-context decisions  | HITL         | HITL        | Lead role   | Team     |
+| Final merge (HITL)          | HITL         | HITL        | `agent:rte` | Team     |
+
+**Agents lead the build; the human owns the judgment.**
+
+---
+
+## Definition of Done
+
+Every issue in this program is done only when all four hold:
+
+- Code is **merged to `{{MAIN_BRANCH}}`** via rebase-and-merge with a
+  `type(scope): description [{{TICKET_PREFIX}}-XXX]` commit.
+- The **relevant gate is now real and green** -- it enforces the thing it claims, with no masking.
+- **Evidence is posted to the tracker** (dev/staging/done as applicable).
+- **No silent suppressions** were added: no new error-swallowing, no broadened ignore globs, no
+  non-blocking downgrade of a check that should block.
+
+---
+
+## Human Gates
+
+> Decisions the agents must never make alone. Surface options with a recommendation, then stop.
+
+- [ ] Approve the program structure and naming
+- [ ] [Any credential rotation or production action -- owned by the human]
+- [ ] Set Bolt target dates
+- [ ] [Fix-versus-suppress budget, if applicable]
+- [ ] [Security policy decisions: CSP allow-list, auth behavior, headers]
+- [ ] [Which CI checks become required]
+- [ ] [Dependency severity policy]
+- [ ] [Any SOP exception]
+- [ ] Sign the Definition of Done and accept each Bolt's evidence
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+| ---- | ------ | ------ |
+| [YYYY-MM-DD] | Program created | [role] |


### PR DESCRIPTION
# Pull Request: SAFe x AI-DLC methodology layer [SAW-39]

## 📋 Summary

**Linear**: [SAW-39](https://linear.app/cheddarfox/issue/SAW-39/epic-safe-ai-dlc-methodology-layer-bolts-units-of-work-program) (epic) · SAW-40, SAW-41, SAW-42, SAW-43, SAW-44

The harness methodology layer is **pure SAFe**. It has no answer for **cadence at agent speed**, and no guidance for structuring a multi-issue **program**.

Verified against `dev` @ v2.10.0: **0 occurrences** of "AI-DLC", "bolt", or "unit of work" anywhere in the repo. `linear-sop` covers issue mechanics only — get/create/update/comment, evidence templates — and says nothing about initiatives, projects, milestones, or dependency graphs.

Meanwhile SAFe's cadence assumes human squads on week-long sprints. Agent teams elaborate, build, and verify a unit of work in hours. **That mismatch is the gap this PR fills.**

This contributes the **SAFe x AI-DLC fusion**, proven downstream on a real 27-ticket remediation program (1 initiative → 8 projects → 27 issues → Bolts 0–5):

- **Bolt** replaces the sprint — an hours-to-days swarm with an entry gate and a hard exit. Exits on *evidence*, not a date.
- **Unit of Work** replaces the Feature — one coherent outcome, a project.
- **Mob Elaboration / Mob Construction** — the Inception and Construction activities.
- **The loop** — AI plans → AI asks → **human validates business context** → AI executes.

Source: AWS [AI-Driven Development Life Cycle](https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/).

**Docs-only.** No scripts, no config, no runtime behaviour changed.

## 🎯 Changes Made

**New skill `safe-ai-dlc`** — at full four-provider parity (GH#49), adapted per provider rather than copied:

- `.claude/skills/safe-ai-dlc/{SKILL.md,README.md}` — MCP-aware
- `.agents/skills/safe-ai-dlc/` — provider-neutral wording ("tracker" not "Linear"), `.gitkeep` subdirs
- `.gemini/skills/safe-ai-dlc/{SKILL.md,README.md}` — manual web-UI/CLI build-out steps
- `.cursor/rules/03-safe-ai-dlc.mdc` — manual activation, core-methodology band

**New docs**

- `docs/guides/SAFE-AI-DLC-METHODOLOGY.md` — the human-facing guide: why the sprint is replaced, the vocabulary, the fusion mapping, how to run a Bolt, the human-gate principle, a worked gate-integrity example, and **when NOT to use a Bolt** (the spike escape hatch)
- `specs_templates/program_template.md` — scaffolding: Units of Work table, bolt timeline with mandatory entry/exit criteria, mermaid DAG, AI-DLC phase index, RACI, four-clause DoD, human-gates checklist

**Extended `linear-sop`** (all 3 provider copies) with the missing program-structure layer: the initiative → project → milestone → issue → sub-issue hierarchy, `blocks`/`blockedBy` DAG wiring, the `bolt:N` / `agent:*` label prerequisites, and the sub-initiative plan-tier fallback to project priority.

**Discovery surfaces** — new README section `Program Cadence: SAFe x AI-DLC`, plus index rows in `.claude/skills/`, `.gemini/skills/`, `.codex/`, `.claude/README.md`, `.gemini/GEMINI.md`, `.cursor/rules/`, `specs_templates/`.

**Count corrections** (verified by enumerating directories, not assumed): skills 18 → 19, `.gemini` skills 17 → 18, cursor rules 16 → 17. Also corrected in `.claude/SETUP.md` and `WORKSPACE-ADOPTION-GUIDE.md`, which had drifted.

## 🧪 Testing

**Fork-sync suite** — 8 of 9 pass.

`tests/test-fork-sync.sh` fails at Test 2.5 (`cat: .../ka-protected/.claude/settings.local.json: No such file or directory`). **This is pre-existing, not caused by this PR** — verified by cloning `origin/dev` clean and running the same test, which fails identically at the same fixture. Flagged for a separate ticket; happy to file one.

**Markdownlint** — every touched file measured per-file against its `origin/dev` baseline:

- All 8 new files: **0 errors**
- All 15 modified files: **identical to baseline** (e.g. `README.md` 39 → 39, `.cursor/rules/README.md` 32 → 32)

I matched each file's existing table/emphasis style rather than imposing a new one, so this adds no lint debt. Note the repo is not currently MD060-clean — those baselines are pre-existing.

## 📊 Impact Analysis

27 files, +1187 / −16. **No breaking changes.** Purely additive: a new skill, two new docs, one new section in an existing skill, and index/count updates. Existing `linear-sop` content is untouched — the program section is appended before Evidence Policy.

Downstream forks are unaffected until they sync; the new skill is opt-in by nature (`user-invocable: false`, model-invoked only when program-shaped work appears).

## 🔄 Multi-Team Coordination

- **Rebased** onto latest `origin/dev` (`a10f722`); linear history, no merge commits
- Targets **`dev`**, not `main`
- Merge via **"Rebase and merge"**

**One decision for the maintainer**: I did **not** add a `HARNESS_CHANGELOG.yml` entry. `releases:` is currently `[]` and `scripts/generate-changelog.sh` exists, so entries appear to be generated at release time rather than hand-written per PR — inventing a version number here felt wrong. **Happy to add one if you'd prefer it in-PR; otherwise it should be picked up when you cut the release.**

## ✅ Pre-merge Checklist

- [x] Provider parity: all four surfaces, both skill index tables
- [x] Every new `README.md` carries the verbatim License + Intellectual Property block (attribution left hardcoded per #31, not templated)
- [x] Placeholders used throughout — `{{TICKET_PREFIX}}`, `{{MAIN_BRANCH}}`, `{{PROJECT_SHORT}}`, `{{HARNESS_VERSION}}`
- [x] No downstream identifiers leaked (`grep -riE "wor-[0-9]|wtfb|senik"` over added files returns nothing)
- [x] Role labels use `agent:system-architect`, matching the actual agent file (the source used a non-existent `agent:architect` — corrected on port)
- [x] Counts verified by enumeration
- [x] No new lint errors
- [ ] HITL merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
