### PR TITLE
feat(harness): add OKF knowledge-vault subsystem [SAW-45]

### DIFF
--- a/.agents/skills/vault-sync/SKILL.md
+++ b/.agents/skills/vault-sync/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: vault-sync
+description: >
+  Detect and repair drift between an OKF knowledge vault and the code it
+  describes. Use after merging significant changes (schema, interfaces,
+  workflows, agent config), when a staleness review is due, or when the user
+  asks to sync, refresh, or update the knowledge vault.
+---
+
+# Vault Sync Skill
+
+> **TEMPLATE**: This skill uses `{{PLACEHOLDER}}` tokens. Replace with your project values before use.
+
+## Purpose
+
+Keep an OKF knowledge vault honest as the code evolves. The vault is a map of the system; this
+skill detects drift between map and territory, regenerates **only** the affected concepts, and
+records the sync.
+
+## When This Skill Applies
+
+Invoke this skill when:
+
+- A significant change merged — schema, public interfaces, CI workflows, agent or skill config
+- A staleness review is due (the `stale-concepts` Base is the queue)
+- The user asks to sync, refresh, or update the knowledge vault
+- A concept is suspected of being wrong
+
+## Key Files
+
+| Path | Role |
+| --- | --- |
+| `<vault>/_meta/vault-config.json` | Machine-readable constitution — types, tags, frontmatter contract |
+| `<vault>/_meta/CONVENTIONS.md` | The human-readable rules |
+| `<vault>/_meta/manifest.json` | ID registry, reverse index, and `baseline_sha` drift watermark |
+| `<vault>/_meta/templates/` | Per-type skeletons |
+| `<vault>/log.md` | Dated changelog |
+| `knowledge-vault/scripts/validate-vault.mjs` | The gate |
+
+## Procedure
+
+### 1. Detect drift
+
+Read the baseline and diff it to HEAD across the watch-list — **the source paths your concepts
+claim to describe**. Configure this list for your project; the example below is illustrative.
+
+```bash
+BASELINE=$(node -e "console.log(require('./<vault>/_meta/manifest.json').baseline_sha)")
+git diff --name-only "$BASELINE"..HEAD -- \
+  'src/**' 'lib/**' 'config/**' '.github/workflows/**' 'docs/**'
+```
+
+A concept is **stale** if and only if a changed path matches its `resource` or an entry in its
+`sources`. Check the manifest first (it is the reverse index); grep concept frontmatter as backup.
+
+This is file-level truth. Do not substitute a time-based heuristic — "older than N days" flags
+everything and teaches people to ignore the flag.
+
+### 2. Detect inventory changes
+
+Re-enumerate your source globs and diff against the manifest.
+
+- **New source, no concept** → create one. **Add the manifest entry first**, so the ID exists in
+  the registry before anything links to it.
+- **Deleted source** → set the concept's `status: deprecated`. **Do not delete the file.** Inbound
+  links must be cleaned first, in a follow-up change; the backlinks pane or the validator's orphan
+  report shows them.
+
+### 3. Regenerate
+
+For a handful of concepts, update inline. For larger sets, fan out generation agents batched by
+area. **Every generation prompt must carry exactly four things:**
+
+1. The type template from `_meta/templates/`
+2. A **golden example** — a real, already-accepted concept of the same type
+3. The hard rules from `_meta/CONVENTIONS.md`, inline
+4. The manifest **ID registry** — links may target only IDs listed there
+
+Every touched concept gets `timestamp:` = today and `verified_against:` = the current short SHA.
+
+**Re-derive facts from the source files. Never patch prose without re-reading the code it
+describes.** Editing a concept to match a changed interface without opening the file is how a
+vault becomes fiction.
+
+### 4. Validate
+
+```bash
+node knowledge-vault/scripts/validate-vault.mjs --vault <vault>
+```
+
+Must exit 0. Markdown lint must pass. Neither is optional.
+
+### 5. Record
+
+Prepend a dated entry to `log.md`: what changed, why (ticket), and the source SHA. Then bump
+`baseline_sha` and `generated` in the manifest.
+
+Ship on a `{{TICKET_PREFIX}}-XXX-vault-sync-<topic>` branch with a `docs(vault): …` commit to
+`{{MAIN_BRANCH}}`. The pull request should name the code changes that triggered the sync.
+
+## Invariants (do not relax)
+
+- Concept-to-concept links never leave the bundle; out-of-bundle links only under `## Citations`
+- Relative markdown links only — no wikilinks, no leading-slash paths, no repo-host URLs for repo files
+- **Link only to IDs in the manifest.** If a concept does not exist, name it in prose and report it
+  as a suggestion — never invent a link
+- One concept per file; H2 sections exactly match the type template, in order
+- Stub types cite their source-of-truth doc; they never restate it
+- **A citation is not re-verification.** Only re-deriving a concept from source bumps its
+  `timestamp` and `verified_against`
+
+## Anti-Patterns (Do NOT use)
+
+```text
+Bumping timestamps on a docs-only pass   (that is laundering, not verification)
+Deleting a concept when its source dies  (deprecate; clean inbound links first)
+Regenerating the whole vault on drift    (regenerate only what the diff implicates)
+Patching prose without reading the code  (the one habit that makes a vault untrustworthy)
+Skipping the validator because "it is just docs"  (drift is invisible without the gate)
+```
+
+## Authoritative References
+
+- `knowledge-vault/docs/GUIDE.md` -- the method and why each rule exists
+- `knowledge-vault/docs/ADOPTION-PLAYBOOK.md` -- running your first build
+- `knowledge-vault/docs/BUILD-PROMPT.md` -- the multi-agent build prompt
+
+## Routes To
+
+- `safe-workflow` — branch, commit, and PR conventions
+- `linear-sop` — recording the sync against a ticket
+- `pattern-discovery` — find existing concepts before writing new ones

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -243,12 +243,13 @@ Scripts in `.claude/hooks/` that are actively wired via `hooks-config.json`:
 
 Skills are model-invoked expertise packs that Claude loads automatically when relevant context is detected.
 
-### Skills Index (19 Skills)
+### Skills Index (20 Skills)
 
 | Skill | Purpose | Related Skills |
 |-------|---------|----------------|
 | [safe-workflow](skills/safe-workflow/) | Branch naming, commit format, PR workflow | release-patterns, git-advanced |
 | [safe-ai-dlc](skills/safe-ai-dlc/) | Program cadence: Units of Work, Bolts, human-in-the-loop gate | linear-sop, safe-workflow, orchestration-patterns |
+| [vault-sync](skills/vault-sync/) | Knowledge-vault drift detection and repair | pattern-discovery, safe-workflow |
 | [release-patterns](skills/release-patterns/) | PR creation, CI/CD validation | safe-workflow, deployment-sop |
 | [pattern-discovery](skills/pattern-discovery/) | Search patterns before implementing | api-patterns, frontend-patterns |
 | [agent-coordination](skills/agent-coordination/) | Agent assignment, blocker escalation | orchestration-patterns, linear-sop |

--- a/.claude/SETUP.md
+++ b/.claude/SETUP.md
@@ -22,7 +22,7 @@ This guide helps you install the SAFe Claude Code harness in a new project.
 # Copy slash commands (24 commands)
 cp -r .claude/commands/ /path/to/your-project/.claude/commands/
 
-# Copy skills (19 model-invoked skills)
+# Copy skills (20 model-invoked skills)
 cp -r .claude/skills/ /path/to/your-project/.claude/skills/
 
 # Copy agent profiles (11 SAFe agents)
@@ -124,7 +124,7 @@ Ask Claude:
 What skills are available?
 ```
 
-Expected: List of 19 skills with descriptions.
+Expected: List of 20 skills with descriptions.
 
 **Known Issue (v2.0.73)**: The `/skills` command has a display bug. Skills work correctly but won't appear in `/skills` output. Ask Claude directly instead.
 
@@ -183,7 +183,7 @@ After setup, your `.claude/` directory should look like:
 │   ├── pre-pr.md
 │   ├── end-work.md
 │   └── ... (21 more)
-├── skills/             # 19 model-invoked skills
+├── skills/             # 20 model-invoked skills
 │   ├── safe-workflow/SKILL.md
 │   ├── pattern-discovery/SKILL.md
 │   ├── rls-patterns/SKILL.md

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -20,6 +20,7 @@ SAFe® is a registered trademark of Scaled Agile, Inc.
 |-------|---------|
 | safe-workflow | Branch naming, commits, PR workflow |
 | safe-ai-dlc | Program cadence: Units of Work, Bolts, human-in-the-loop gate |
+| vault-sync | Knowledge-vault drift detection and repair |
 | release-patterns | PR creation, CI/CD validation |
 | pattern-discovery | Search patterns before implementing |
 | agent-coordination | Agent assignment, blockers |

--- a/.claude/skills/vault-sync/README.md
+++ b/.claude/skills/vault-sync/README.md
@@ -1,0 +1,59 @@
+# Vault Sync
+
+![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-{{HARNESS_VERSION}}-blue)
+
+> Detect and repair drift between an OKF knowledge vault and the code it describes. Regenerates only what changed, and records the sync.
+
+## License
+
+**License:** MIT (see [/LICENSE](/LICENSE))
+**Copyright:** © 2026 J. Scott Graham ([@cheddarfox](https://github.com/cheddarfox)) / [ByBren, LLC](https://github.com/bybren-llc)
+**Attribution:** Required per [/NOTICE](/NOTICE)
+
+## Intellectual Property
+
+The skill system architecture and {{PROJECT_SHORT}} harness methodology are the intellectual property of J. Scott Graham and ByBren, LLC.
+
+SAFe® is a registered trademark of Scaled Agile, Inc.
+
+## Quick Start
+
+This skill activates automatically when you:
+
+- Merge a significant change to schema, interfaces, workflows, or agent config
+- Ask to sync, refresh, or update the knowledge vault
+- Run a staleness review
+- Suspect a concept has gone out of date
+
+## What This Skill Does
+
+Drives the five-step maintenance loop that keeps a knowledge vault trustworthy: read `baseline_sha` and diff it to HEAD across the watch-list, map changed paths back to the concepts that claim to describe them, regenerate **only** those, validate, and record the sync in the log.
+
+Staleness is computed, not guessed — a concept is stale if and only if a file it names in `resource` or `sources` actually changed. The skill also enforces the discipline that keeps the mechanism honest: **a citation is not re-verification**, and only re-deriving a concept from source bumps its `timestamp` and `verified_against`.
+
+## Trigger Keywords
+
+| Primary | Secondary |
+| --- | --- |
+| vault | drift |
+| knowledge base | stale |
+| sync | Obsidian |
+| concepts | verified_against |
+
+## Related Skills
+
+- [pattern-discovery](../pattern-discovery/) - Find existing concepts before writing new ones
+- [safe-workflow](../safe-workflow/) - Branch, commit, and PR conventions
+- [linear-sop](../linear-sop/) - Recording the sync against a ticket
+
+## Maintenance
+
+| Field | Value |
+| --- | --- |
+| Last Updated | 2026-07-19 |
+| Harness Version | {{HARNESS_VERSION}} |
+
+---
+
+*Full implementation details in [SKILL.md](SKILL.md)*

--- a/.claude/skills/vault-sync/SKILL.md
+++ b/.claude/skills/vault-sync/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: vault-sync
+description: Detect and repair drift between an OKF knowledge vault and the code it describes. Use after merging significant changes (schema, routes, workflows, agent config), when a staleness review is due, or when the user asks to sync, refresh, or update the knowledge vault or Obsidian vault.
+user-invocable: true
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# Vault Sync Skill
+
+> **📋 TEMPLATE**: This skill uses `{{TICKET_PREFIX}}` and `{{MAIN_BRANCH}}` as placeholders, and
+> assumes a vault created from `knowledge-vault/templates/starter-bundle`.
+
+## Purpose
+
+Keep an OKF knowledge vault honest as the code evolves. The vault is a map of the system; this
+skill detects drift between map and territory, regenerates **only** the affected concepts, and
+records the sync.
+
+## When This Skill Applies
+
+Invoke this skill when:
+
+- A significant change merged — schema, public interfaces, CI workflows, agent or skill config
+- A staleness review is due (the `stale-concepts` Base is the queue)
+- The user asks to sync, refresh, or update the knowledge vault
+- A concept is suspected of being wrong
+
+## Key Files
+
+| Path | Role |
+| --- | --- |
+| `<vault>/_meta/vault-config.json` | Machine-readable constitution — types, tags, frontmatter contract |
+| `<vault>/_meta/CONVENTIONS.md` | The human-readable rules |
+| `<vault>/_meta/manifest.json` | ID registry, reverse index, and `baseline_sha` drift watermark |
+| `<vault>/_meta/templates/` | Per-type skeletons |
+| `<vault>/log.md` | Dated changelog |
+| `knowledge-vault/scripts/validate-vault.mjs` | The gate |
+
+## Procedure
+
+### 1. Detect drift
+
+Read the baseline and diff it to HEAD across the watch-list — **the source paths your concepts
+claim to describe**. Configure this list for your project; the example below is illustrative.
+
+```bash
+BASELINE=$(node -e "console.log(require('./<vault>/_meta/manifest.json').baseline_sha)")
+git diff --name-only "$BASELINE"..HEAD -- \
+  'src/**' 'lib/**' 'config/**' '.github/workflows/**' 'docs/**'
+```
+
+A concept is **stale** if and only if a changed path matches its `resource` or an entry in its
+`sources`. Check the manifest first (it is the reverse index); grep concept frontmatter as backup.
+
+This is file-level truth. Do not substitute a time-based heuristic — "older than N days" flags
+everything and teaches people to ignore the flag.
+
+### 2. Detect inventory changes
+
+Re-enumerate your source globs and diff against the manifest.
+
+- **New source, no concept** → create one. **Add the manifest entry first**, so the ID exists in
+  the registry before anything links to it.
+- **Deleted source** → set the concept's `status: deprecated`. **Do not delete the file.** Inbound
+  links must be cleaned first, in a follow-up change; the backlinks pane or the validator's orphan
+  report shows them.
+
+### 3. Regenerate
+
+For a handful of concepts, update inline. For larger sets, fan out generation agents batched by
+area. **Every generation prompt must carry exactly four things:**
+
+1. The type template from `_meta/templates/`
+2. A **golden example** — a real, already-accepted concept of the same type
+3. The hard rules from `_meta/CONVENTIONS.md`, inline
+4. The manifest **ID registry** — links may target only IDs listed there
+
+Every touched concept gets `timestamp:` = today and `verified_against:` = the current short SHA.
+
+**Re-derive facts from the source files. Never patch prose without re-reading the code it
+describes.** Editing a concept to match a changed interface without opening the file is how a
+vault becomes fiction.
+
+### 4. Validate
+
+```bash
+node knowledge-vault/scripts/validate-vault.mjs --vault <vault>
+```
+
+Must exit 0. Markdown lint must pass. Neither is optional.
+
+### 5. Record
+
+Prepend a dated entry to `log.md`: what changed, why (ticket), and the source SHA. Then bump
+`baseline_sha` and `generated` in the manifest.
+
+Ship on a `{{TICKET_PREFIX}}-XXX-vault-sync-<topic>` branch with a `docs(vault): …` commit to
+`{{MAIN_BRANCH}}`. The pull request should name the code changes that triggered the sync.
+
+## Invariants (do not relax)
+
+- Concept-to-concept links never leave the bundle; out-of-bundle links only under `## Citations`
+- Relative markdown links only — no wikilinks, no leading-slash paths, no repo-host URLs for repo files
+- **Link only to IDs in the manifest.** If a concept does not exist, name it in prose and report it
+  as a suggestion — never invent a link
+- One concept per file; H2 sections exactly match the type template, in order
+- Stub types cite their source-of-truth doc; they never restate it
+- **A citation is not re-verification.** Only re-deriving a concept from source bumps its
+  `timestamp` and `verified_against`
+
+## Anti-Patterns (Do NOT use)
+
+```text
+Bumping timestamps on a docs-only pass   (that is laundering, not verification)
+Deleting a concept when its source dies  (deprecate; clean inbound links first)
+Regenerating the whole vault on drift    (regenerate only what the diff implicates)
+Patching prose without reading the code  (the one habit that makes a vault untrustworthy)
+Skipping the validator because "it is just docs"  (drift is invisible without the gate)
+```
+
+## Authoritative References
+
+- `knowledge-vault/docs/GUIDE.md` -- the method and why each rule exists
+- `knowledge-vault/docs/ADOPTION-PLAYBOOK.md` -- running your first build
+- `knowledge-vault/docs/BUILD-PROMPT.md` -- the multi-agent build prompt
+
+## Routes To
+
+- `safe-workflow` — branch, commit, and PR conventions
+- `linear-sop` — recording the sync against a ticket
+- `pattern-discovery` — find existing concepts before writing new ones

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -88,12 +88,13 @@ Each skill follows this structure:
 
 Skills are **shared across all agents** (not Codex-specific). The same `.agents/skills/` directory is used by any tool that supports the convention.
 
-#### Available Skills (19)
+#### Available Skills (20)
 
 | Skill | Description |
 |-------|-------------|
 | `safe-workflow` | Branch naming, commits, PR workflow |
 | `safe-ai-dlc` | Program cadence: Units of Work, Bolts, human-in-the-loop gate |
+| `vault-sync` | Knowledge-vault drift detection and repair |
 | `pattern-discovery` | Pattern library discovery |
 | `testing-patterns` | Unit, integration, E2E patterns |
 | `api-patterns` | REST API implementation patterns |

--- a/.cursor/rules/04-knowledge-vault.mdc
+++ b/.cursor/rules/04-knowledge-vault.mdc
@@ -1,0 +1,70 @@
+---
+description: "OKF knowledge-vault conventions: the frontmatter contract, link rules, verified_against drift discipline, and the vault-sync loop. Activate when authoring or maintaining knowledge-vault concepts."
+alwaysApply: false
+---
+
+# Knowledge Vault Conventions
+
+Activate this rule when writing or maintaining concepts in an OKF knowledge vault.
+
+A vault is a **map, not the territory**. Source-of-truth docs stay where they live; code stays
+authoritative over everything, including the vault. A concept is a ~50-line map-card that
+summarizes and links — it never restates its source.
+
+## The Frontmatter Contract
+
+Required on every concept: `type`, `title`, `description` (≤160 chars), `tags`, `timestamp`,
+`status`.
+
+`timestamp` is **the date the concept was last verified against its sources** — not the date the
+file was edited. Optional: `resource`, `domain`, `ticket`, `sources`, `docs`, `verified_against`.
+
+**YAML subset only** — scalars, double-quoted strings, inline lists, and two-space block lists. No
+nested maps, no multiline scalars. This is what keeps the validator dependency-free.
+
+## Link Rules
+
+1. Relative markdown links only. **No wikilinks**, no leading-slash paths, no repo-host URLs for
+   files in this repo.
+2. Concept-to-concept links never leave the bundle.
+3. Links that leave the bundle appear only under `## Citations` (`index.md` and `guide` types are
+   exempt — they are navigation).
+4. **Link only to concept IDs listed in `_meta/manifest.json`.** If the concept does not exist,
+   name it in prose and report it as a suggestion. **Never invent a link.**
+
+Rule 4 is the one that matters most when several agents author in parallel. Without it you get a
+graph of plausible, confident, broken references.
+
+## Writing Rules
+
+- **Summarize, never duplicate.** If you are restating more than a paragraph, stop and link.
+- **Code wins.** Name the helper actually called, not the one the code *should* call. When code
+  contradicts docs, document the code and note the discrepancy.
+- Section H2s must exactly match the type's template, in order. Do not add, remove, or rename.
+- Environment variable names may be mentioned; values never.
+- No emoji in concept files.
+
+## Drift Discipline
+
+Staleness is computed, not felt: a concept is stale if and only if a path in its `resource` or
+`sources` changed since the manifest's `baseline_sha`.
+
+**A citation is not re-verification.** Linking a concept from somewhere new does not make its
+claims fresher. Only re-deriving it from source bumps `timestamp` and `verified_against`.
+
+Deleted source → `status: deprecated`, never a file deletion; inbound links must be cleaned first.
+
+## Before You Commit
+
+```bash
+node knowledge-vault/scripts/validate-vault.mjs --vault <vault>
+```
+
+Must exit 0. Prepend a dated entry to `log.md` and bump the `timestamp` of every concept you
+actually re-verified.
+
+## References
+
+- `knowledge-vault/docs/GUIDE.md` -- the method and why each rule exists
+- `knowledge-vault/docs/ADOPTION-PLAYBOOK.md` -- running your first build
+- `knowledge-vault/templates/starter-bundle/_meta/CONVENTIONS.md` -- the full constitution

--- a/.cursor/rules/README.md
+++ b/.cursor/rules/README.md
@@ -27,6 +27,7 @@ Cursor uses `.cursor/rules/*.mdc` files with YAML frontmatter to provide context
 | File | Purpose |
 | --- | --- |
 | `03-safe-ai-dlc.mdc` | SAFe x AI-DLC program cadence: Bolts, Units of Work, Mob Elaboration, human-gate checklist |
+| `04-knowledge-vault.mdc` | OKF knowledge-vault conventions: frontmatter contract, link rules, drift discipline |
 
 ### Auto-Attached Tech Rules (active when matching files are open)
 
@@ -129,7 +130,7 @@ Reference these when working with background agents or MCP:
 1. **DRY**: Rules reference existing docs (CLAUDE.md, AGENTS.md, patterns_library/) rather than duplicating content
 2. **Concise**: Each rule stays under 200 lines to respect Cursor's context limits
 3. **Template-Ready**: Uses `{{TICKET_PREFIX}}`, `{{MAIN_BRANCH}}`, and other placeholders for project customization
-4. **Hierarchical**: Numbering (00-02, 10-16, 20-23, 30-31) groups rules by activation type
+4. **Hierarchical**: Numbering (00-02 core, 03-04 methodology, 10-16 tech, 20-23 roles, 30-31 advanced) groups rules by activation type
 
 ## Relationship to Other Configurations
 

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -26,12 +26,13 @@ All work requires verifiable evidence attached to Linear tickets:
 
 ## Available Skills
 
-Skills auto-load when context matches. All 18 skills:
+Skills auto-load when context matches. All 19 skills:
 
 | Skill | Trigger When |
 |-------|--------------|
 | `safe-workflow` | Starting work, commits, branches, PRs |
 | `safe-ai-dlc` | Planning or running a multi-issue program |
+| `vault-sync` | Knowledge vault drift or staleness |
 | `pattern-discovery` | Before implementing features |
 | `rls-patterns` | Database operations, RLS policies |
 | `api-patterns` | Creating API endpoints |

--- a/.gemini/README.md
+++ b/.gemini/README.md
@@ -35,7 +35,7 @@ The CLI will automatically detect and load skills from `.gemini/skills/` and com
 ├── GEMINI.md           # System instructions (auto-loaded)
 ├── README.md           # This file
 ├── settings.json       # Configuration template
-├── skills/             # Auto-loaded skills (17 total)
+├── skills/             # Auto-loaded skills (19 total)
 │   ├── safe-workflow/
 │   │   └── SKILL.md
 │   ├── pattern-discovery/

--- a/.gemini/README.md
+++ b/.gemini/README.md
@@ -65,7 +65,7 @@ Skills provide contextual knowledge that auto-loads when relevant. View availabl
 gemini /skills
 ```
 
-### Included Skills (18)
+### Included Skills (19)
 
 | Skill | Description |
 |-------|-------------|

--- a/.gemini/skills/README.md
+++ b/.gemini/skills/README.md
@@ -14,12 +14,13 @@ The skill system architecture and {{PROJECT_SHORT}} harness methodology are the 
 
 SAFe® is a registered trademark of Scaled Agile, Inc.
 
-## Skills Included (18)
+## Skills Included (19)
 
 | Skill | Purpose |
 |-------|---------|
 | safe-workflow | Branch naming, commits, PR workflow |
 | safe-ai-dlc | Program cadence: Units of Work, Bolts, human-in-the-loop gate |
+| vault-sync | Knowledge-vault drift detection and repair |
 | release-patterns | PR creation, CI/CD validation |
 | pattern-discovery | Search patterns before implementing |
 | agent-coordination | Agent assignment, blockers |

--- a/.gemini/skills/vault-sync/README.md
+++ b/.gemini/skills/vault-sync/README.md
@@ -1,0 +1,57 @@
+# Vault Sync
+
+![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-{{HARNESS_VERSION}}-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
+
+> Detect and repair drift between an OKF knowledge vault and the code it describes. Regenerates only what changed, and records the sync.
+
+## License
+
+**License:** MIT (see [/LICENSE](/LICENSE))
+**Copyright:** © 2026 J. Scott Graham ([@cheddarfox](https://github.com/cheddarfox)) / [ByBren, LLC](https://github.com/bybren-llc)
+**Attribution:** Required per [/NOTICE](/NOTICE)
+
+## Intellectual Property
+
+The skill system architecture and {{PROJECT_SHORT}} harness methodology are the intellectual property of J. Scott Graham and ByBren, LLC.
+
+SAFe® is a registered trademark of Scaled Agile, Inc.
+
+## Quick Start
+
+This skill activates automatically when you mention:
+
+- Syncing, refreshing, or updating the knowledge vault
+- Vault drift or stale concepts
+- A significant merge that may have invalidated documentation
+
+## What This Skill Does
+
+Drives the five-step loop that keeps a knowledge vault trustworthy: diff `baseline_sha` to HEAD across the watch-list, map changed paths back to the concepts that describe them, regenerate only those, validate, and record the sync.
+
+Staleness is computed rather than guessed — a concept is stale if and only if a file it names in `resource` or `sources` actually changed. Enforces the discipline that keeps the mechanism honest: **a citation is not re-verification**.
+
+## Provider Compatibility
+
+| Provider | Status |
+| --- | --- |
+| Gemini CLI | ✅ Native (drift detection and validation are shell commands) |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
+
+## Related Skills
+
+- [pattern-discovery](../pattern-discovery/) - Find existing concepts first
+- [safe-workflow](../safe-workflow/) - Workflow standards
+- [linear-sop](../linear-sop/) - Recording the sync against a ticket
+
+## Maintenance
+
+| Field | Value |
+| --- | --- |
+| Last Updated | 2026-07-19 |
+| Harness Version | {{HARNESS_VERSION}} |
+
+---
+
+*Full implementation details in [SKILL.md](SKILL.md)*

--- a/.gemini/skills/vault-sync/SKILL.md
+++ b/.gemini/skills/vault-sync/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: vault-sync
+description: Detect and repair drift between an OKF knowledge vault and the code it describes. Use after merging significant changes (schema, interfaces, workflows, agent config), when a staleness review is due, or when the user asks to sync, refresh, or update the knowledge vault.
+---
+
+# Vault Sync Skill
+
+> **📋 TEMPLATE**: This skill uses `{{TICKET_PREFIX}}` and `{{MAIN_BRANCH}}` as placeholders, and
+> assumes a vault created from `knowledge-vault/templates/starter-bundle`.
+
+## Purpose
+
+Keep an OKF knowledge vault honest as the code evolves. The vault is a map of the system; this
+skill detects drift between map and territory, regenerates **only** the affected concepts, and
+records the sync.
+
+## When This Skill Applies
+
+Invoke this skill when:
+
+- A significant change merged — schema, public interfaces, CI workflows, agent or skill config
+- A staleness review is due (the `stale-concepts` Base is the queue)
+- The user asks to sync, refresh, or update the knowledge vault
+- A concept is suspected of being wrong
+
+## Key Files
+
+| Path | Role |
+| --- | --- |
+| `<vault>/_meta/vault-config.json` | Machine-readable constitution — types, tags, frontmatter contract |
+| `<vault>/_meta/CONVENTIONS.md` | The human-readable rules |
+| `<vault>/_meta/manifest.json` | ID registry, reverse index, and `baseline_sha` drift watermark |
+| `<vault>/_meta/templates/` | Per-type skeletons |
+| `<vault>/log.md` | Dated changelog |
+| `knowledge-vault/scripts/validate-vault.mjs` | The gate |
+
+## Procedure
+
+> Gemini CLI has no native vault tooling. Steps 1, 4 and 5 are shell commands you run
+> directly; steps 2 and 3 are authoring work.
+
+### 1. Detect drift
+
+Read the baseline and diff it to HEAD across the watch-list — **the source paths your concepts
+claim to describe**. Configure this list for your project; the example below is illustrative.
+
+```bash
+BASELINE=$(node -e "console.log(require('./<vault>/_meta/manifest.json').baseline_sha)")
+git diff --name-only "$BASELINE"..HEAD -- \
+  'src/**' 'lib/**' 'config/**' '.github/workflows/**' 'docs/**'
+```
+
+A concept is **stale** if and only if a changed path matches its `resource` or an entry in its
+`sources`. Check the manifest first (it is the reverse index); grep concept frontmatter as backup.
+
+This is file-level truth. Do not substitute a time-based heuristic — "older than N days" flags
+everything and teaches people to ignore the flag.
+
+### 2. Detect inventory changes
+
+Re-enumerate your source globs and diff against the manifest.
+
+- **New source, no concept** → create one. **Add the manifest entry first**, so the ID exists in
+  the registry before anything links to it.
+- **Deleted source** → set the concept's `status: deprecated`. **Do not delete the file.** Inbound
+  links must be cleaned first, in a follow-up change; the backlinks pane or the validator's orphan
+  report shows them.
+
+### 3. Regenerate
+
+For a handful of concepts, update inline. For larger sets, fan out generation agents batched by
+area. **Every generation prompt must carry exactly four things:**
+
+1. The type template from `_meta/templates/`
+2. A **golden example** — a real, already-accepted concept of the same type
+3. The hard rules from `_meta/CONVENTIONS.md`, inline
+4. The manifest **ID registry** — links may target only IDs listed there
+
+Every touched concept gets `timestamp:` = today and `verified_against:` = the current short SHA.
+
+**Re-derive facts from the source files. Never patch prose without re-reading the code it
+describes.** Editing a concept to match a changed interface without opening the file is how a
+vault becomes fiction.
+
+### 4. Validate
+
+```bash
+node knowledge-vault/scripts/validate-vault.mjs --vault <vault>
+```
+
+Must exit 0. Markdown lint must pass. Neither is optional.
+
+### 5. Record
+
+Prepend a dated entry to `log.md`: what changed, why (ticket), and the source SHA. Then bump
+`baseline_sha` and `generated` in the manifest.
+
+Ship on a `{{TICKET_PREFIX}}-XXX-vault-sync-<topic>` branch with a `docs(vault): …` commit to
+`{{MAIN_BRANCH}}`. The pull request should name the code changes that triggered the sync.
+
+## Invariants (do not relax)
+
+- Concept-to-concept links never leave the bundle; out-of-bundle links only under `## Citations`
+- Relative markdown links only — no wikilinks, no leading-slash paths, no repo-host URLs for repo files
+- **Link only to IDs in the manifest.** If a concept does not exist, name it in prose and report it
+  as a suggestion — never invent a link
+- One concept per file; H2 sections exactly match the type template, in order
+- Stub types cite their source-of-truth doc; they never restate it
+- **A citation is not re-verification.** Only re-deriving a concept from source bumps its
+  `timestamp` and `verified_against`
+
+## Anti-Patterns (Do NOT use)
+
+```text
+Bumping timestamps on a docs-only pass   (that is laundering, not verification)
+Deleting a concept when its source dies  (deprecate; clean inbound links first)
+Regenerating the whole vault on drift    (regenerate only what the diff implicates)
+Patching prose without reading the code  (the one habit that makes a vault untrustworthy)
+Skipping the validator because "it is just docs"  (drift is invisible without the gate)
+```
+
+## Authoritative References
+
+- `knowledge-vault/docs/GUIDE.md` -- the method and why each rule exists
+- `knowledge-vault/docs/ADOPTION-PLAYBOOK.md` -- running your first build
+- `knowledge-vault/docs/BUILD-PROMPT.md` -- the multi-agent build prompt
+
+## Routes To
+
+- `safe-workflow` — branch, commit, and PR conventions
+- `linear-sop` — recording the sync against a ticket
+- `pattern-discovery` — find existing concepts before writing new ones

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Skills are loaded progressively—metadata at startup, full content when context
 | ------------------------ | ---------------------- | ------------------------------------------- |
 | `safe-workflow`          | Commits, branches, PRs | SAFe format, rebase-first workflow          |
 | `safe-ai-dlc`            | Multi-issue programs   | Bolts, Units of Work, HITL gate             |
+| `vault-sync`             | Knowledge vault drift  | Detect staleness, regenerate, record        |
 | `pattern-discovery`      | Before writing code    | Pattern-first development (MANDATORY)       |
 | `rls-patterns`           | Database operations    | RLS context helpers (withUserContext, etc.) |
 | `frontend-patterns`      | UI work                | Clerk, shadcn, Next.js patterns             |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ This is a **SAFe multi-agent development project** with 11 specialized AI agents
 - [docs/onboarding/](docs/onboarding/) - Setup guides and daily workflows
 - [docs/guides/ROUND-TABLE-PHILOSOPHY.md](docs/guides/ROUND-TABLE-PHILOSOPHY.md) - Collaboration principles
 - [patterns_library/](patterns_library/) - Reusable code patterns (18+ patterns, 7 categories)
+- [knowledge-vault/](knowledge-vault/README.md) - Evidence-verified knowledge base. To build this repo's own vault, run [SAW-VAULT-BUILD.md](knowledge-vault/docs/SAW-VAULT-BUILD.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@
     <img src="https://img.shields.io/badge/agents-11%20SAFe%20roles-red?style=flat-square" alt="Agents">
   </a>
   <a href=".claude/skills/">
-    <img src="https://img.shields.io/badge/skills-19%20model--invoked-purple?style=flat-square" alt="Skills">
+    <img src="https://img.shields.io/badge/skills-20%20model--invoked-purple?style=flat-square" alt="Skills">
   </a>
   <a href=".claude/commands/">
     <img src="https://img.shields.io/badge/commands-24%20workflows-orange?style=flat-square" alt="Commands">
   </a>
   <a href=".cursor/rules/">
-    <img src="https://img.shields.io/badge/cursor%20rules-17-00D084?style=flat-square" alt="Cursor Rules">
+    <img src="https://img.shields.io/badge/cursor%20rules-18-00D084?style=flat-square" alt="Cursor Rules">
   </a>
 </p>
 
@@ -67,6 +67,7 @@ Includes:
 - **Three-Layer Architecture** - Hooks → Commands → Skills
 - **Agent Teams** - Multi-agent orchestration with SAFe quality gates (experimental)
 - **Dark Factory** - Persistent autonomous agent teams via tmux on remote servers ([guide](dark-factory/README.md))
+- **Knowledge Vault** - Evidence-verified knowledge base with a drift-detecting validator ([guide](knowledge-vault/README.md))
 
 > **Origin**: 5 months production use, 169 issues, 2,193 commits. Implements patterns from
 > [6 Anthropic engineering papers](#implementing-anthropics-research) and [SAFe methodology](https://scaledagileframework.com/).
@@ -204,6 +205,7 @@ bash scripts/setup-template.sh                # Re-apply your placeholders
 **Upgrading from a previous version?** See [Keeping the Harness Updated](docs/guides/WORKSPACE-ADOPTION-GUIDE.md#keeping-the-harness-updated).
 **Syncing your fork with upstream?** See the [Harness Sync Guide](docs/HARNESS_SYNC_GUIDE.md).
 **Planning a multi-issue program?** See the [SAFe x AI-DLC Methodology](docs/guides/SAFE-AI-DLC-METHODOLOGY.md).
+**Building a knowledge base?** See the [Knowledge Vault](knowledge-vault/README.md).
 
 ### Key Commands
 
@@ -355,7 +357,7 @@ This harness directly implements patterns from Anthropic's engineering papers:
 | ----------------------------------------------------------------------------------------------------------- | -------------------------- |
 | [Building Effective Agents](https://www.anthropic.com/engineering/building-effective-agents)                | 11-agent team structure    |
 | [Effective Harnesses](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)    | Three-layer architecture   |
-| [Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) | 19 model-invoked skills    |
+| [Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) | 20 model-invoked skills    |
 | [Skills Announcement](https://www.anthropic.com/news/skills)                                                | Skills 2.0 frontmatter, trigger patterns |
 | [Code Execution with MCP](https://www.anthropic.com/engineering/code-execution-with-mcp)                    | Tool restrictions per role |
 
@@ -424,6 +426,48 @@ Use it when work spans **many issues and needs cadence** — turning an audit, e
 an executable program. For a single ticket, the standard `safe-workflow` path is correct. And if the
 problem space is still unclear, run a **spike** instead: forcing an ambiguous epic into one Bolt just
 relocates the ambiguity into the code.
+
+---
+
+## Knowledge Vault
+
+Agent teams need a shared map of the system, and a map nobody can prove is current will quietly
+become wrong. The `knowledge-vault/` subsystem is an **evidence-verified knowledge base**: every
+concept records the commit its claims were checked against, so staleness is something you
+**compute**, not something you feel.
+
+Built on [Open Knowledge Format v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+(Google, Apache-2.0), which gives portability. This harness adds the rigor layer that gives trust:
+a strict frontmatter contract, a zero-dependency validator, an anti-hallucination link rule, and a
+drift mechanism.
+
+In the project this method came from, an independent architecture audit called the vault _"the
+single strongest KT asset in the repo"_ and told new developers to trust it **over** the project's
+own canonical context file — because the vault's claims were verified against a SHA and the
+canonical file's had silently drifted.
+
+### Run It
+
+| Prompt | Who it is for |
+| --- | --- |
+| [BUILD-PROMPT.md](knowledge-vault/docs/BUILD-PROMPT.md) | **Every adopter** — the generic multi-agent build prompt. Fill in your project, taxonomy, and watch-list, then run it. |
+| [SAW-VAULT-BUILD.md](knowledge-vault/docs/SAW-VAULT-BUILD.md) | **This repo's maintainers** — pre-scoped to {{PROJECT_SHORT}} and runnable as-is, with a ready-to-file ticket breakdown. |
+
+```bash
+# Prove the tooling works before you trust it
+node knowledge-vault/scripts/validate-vault.mjs --vault knowledge-vault/templates/starter-bundle
+```
+
+| Resource | Purpose |
+| --- | --- |
+| [Knowledge Vault README](knowledge-vault/README.md) | Start here — 30-second quickstart |
+| [Guide](knowledge-vault/docs/GUIDE.md) | The method, and why each rule exists |
+| [Adoption Playbook](knowledge-vault/docs/ADOPTION-PLAYBOOK.md) | Steps, taxonomy choice, CI gating, ticket breakdown |
+| [Obsidian Guide](knowledge-vault/docs/OBSIDIAN-GUIDE.md) | Graph, canvases, Bases, and the config treaty |
+| `vault-sync` skill | Drift detection and repair, all four providers |
+
+Obsidian is optional — no community plugins required, and the vault degrades to plain markdown in
+any editor.
 
 ---
 
@@ -1303,14 +1347,14 @@ See [Agent Workflow SOP v1.4](docs/sop/AGENT_WORKFLOW_SOP.md) for complete detai
 ```text
 .claude/                 # Claude Code harness (primary provider)
 ├── commands/            # 24 slash commands for workflow automation
-├── skills/              # 19 model-invoked skills for domain expertise
+├── skills/              # 20 model-invoked skills for domain expertise
 ├── agents/              # 11 SAFe agent profiles
 ├── team-config.json     # Agent Teams settings (optional, experimental)
 └── SETUP.md             # Installation and customization guide
 
 .gemini/                 # Gemini CLI harness (secondary provider)
 ├── commands/            # 30 TOML commands (namespaced: /workflow:*, /local:*, /remote:*, /media:*)
-├── skills/              # 18 model-invoked skills (team-coordination is Claude-only)
+├── skills/              # 19 model-invoked skills (team-coordination is Claude-only)
 ├── settings.json        # Configuration (model, hooks, policy, security)
 ├── GEMINI.md            # System instructions
 └── README.md            # Gemini-specific setup guide
@@ -1323,12 +1367,19 @@ See [Agent Workflow SOP v1.4](docs/sop/AGENT_WORKFLOW_SOP.md) for complete detai
 └── rules/               # .mdc rule files with YAML frontmatter activation
     ├── 00-02            # Always-apply core rules (SAFe, git, patterns)
     ├── 03               # SAFe x AI-DLC program cadence (manual activation)
+    ├── 04               # Knowledge-vault conventions (manual activation)
     ├── 10-13            # Auto-attached tech rules (Python, React, SQL, tests)
     ├── 20-23            # Agent-role rules (Architect, Backend, QAS, Security)
     └── 30-31            # Background agents and MCP integration
 
 .agents/                 # Shared agent skills (discovered by Codex and other agents)
-└── skills/              # 19 cross-provider skills (api-patterns, safe-workflow, etc.)
+└── skills/              # 20 cross-provider skills (api-patterns, safe-workflow, etc.)
+
+knowledge-vault/         # OKF knowledge-base subsystem (optional)
+├── docs/                # Method, playbook, build prompts, Obsidian guide
+├── templates/           # Starter bundle, Obsidian config, CI workflow
+├── scripts/             # validate-vault.mjs (zero dependencies)
+└── tests/               # Proof that each validator gate fails when broken
 
 dark-factory/            # tmux Agent Teams infrastructure (optional)
 ├── scripts/             # factory-setup, start, stop, status, attach

--- a/docs/guides/WORKSPACE-ADOPTION-GUIDE.md
+++ b/docs/guides/WORKSPACE-ADOPTION-GUIDE.md
@@ -112,7 +112,7 @@ grep -c '{{' CLAUDE.md AGENTS.md CONTRIBUTING.md .claude/team-config.json
 
 # Confirm harness structure
 ls .claude/agents/ | wc -l  # 11 agents
-ls .claude/skills/ | wc -l  # 19 skills
+ls .claude/skills/ | wc -l  # 20 skills
 ls .claude/commands/ | wc -l  # 23+ commands
 ```
 

--- a/docs/whitepapers/ANTHROPIC-RESEARCH-ALIGNMENT.md
+++ b/docs/whitepapers/ANTHROPIC-RESEARCH-ALIGNMENT.md
@@ -233,7 +233,7 @@ Skills activate based on context triggers, providing just-in-time expertise:
 - `safe-workflow` activates when making commits, branches, or PRs
 - `pattern-discovery` activates before writing any code
 
-This implements the separation of concerns principle. The agent does not carry all 19 skills in active context simultaneously. Skills surface when relevant, keeping the active context focused and performant.
+This implements the separation of concerns principle. The agent does not carry all 20 skills in active context simultaneously. Skills surface when relevant, keeping the active context focused and performant.
 
 **Specs (Session-Level Context)**
 

--- a/docs/whitepapers/CLAUDE-CODE-HARNESS-KT-META-PROMPT.md
+++ b/docs/whitepapers/CLAUDE-CODE-HARNESS-KT-META-PROMPT.md
@@ -455,7 +455,7 @@ Check PR #324 or subsequent PRs for full diff and review discussion.
 ├── .claude/
 │   ├── settings.json          # Hooks configuration
 │   ├── commands/              # 24 slash commands
-│   ├── skills/                # 19 model-invoked skills
+│   ├── skills/                # 20 model-invoked skills
 │   └── agents/                # 12 agent profiles
 ├── AGENTS.md                  # Quick reference
 ├── CONTRIBUTING.md            # Workflow documentation

--- a/docs/whitepapers/README.md
+++ b/docs/whitepapers/README.md
@@ -12,7 +12,7 @@ The complete technical documentation of the three-layer harness architecture:
 
 - Background and motivation
 - Three-layer architecture (Hooks → Commands → Skills)
-- All 19 skills with implementation details
+- All 20 skills with implementation details
 - All 24 slash commands organized by category
 - Phase 0-3 completion history
 - SAFe role expansion vision

--- a/knowledge-vault/.markdownlint.json
+++ b/knowledge-vault/.markdownlint.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../.markdownlint.json",
+
+  "MD025": {
+    "front_matter_title": ""
+  },
+
+  "MD024": {
+    "siblings_only": true
+  }
+}

--- a/knowledge-vault/.markdownlint.json
+++ b/knowledge-vault/.markdownlint.json
@@ -7,5 +7,13 @@
 
   "MD024": {
     "siblings_only": true
-  }
+  },
+
+  "MD040": true,
+
+  "MD055": {
+    "style": "leading_and_trailing"
+  },
+
+  "MD056": true
 }

--- a/knowledge-vault/README.md
+++ b/knowledge-vault/README.md
@@ -1,0 +1,122 @@
+# Knowledge Vault
+
+![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-{{HARNESS_VERSION}}-blue)
+![Format](https://img.shields.io/badge/format-OKF%20v0.1-blue)
+
+> An evidence-verified knowledge base for agent teams. Every concept records the commit its claims
+> were checked against, so staleness is something you **compute**, not something you feel.
+
+## License
+
+**License:** MIT (see [/LICENSE](/LICENSE))
+**Copyright:** © 2026 J. Scott Graham ([@cheddarfox](https://github.com/cheddarfox)) / [ByBren, LLC](https://github.com/bybren-llc)
+**Attribution:** Required per [/NOTICE](/NOTICE)
+
+## Intellectual Property
+
+The skill system architecture and {{PROJECT_SHORT}} harness methodology are the intellectual property of J. Scott Graham and ByBren, LLC.
+
+SAFe® is a registered trademark of Scaled Agile, Inc.
+
+---
+
+## Run It
+
+Two prompts. One is a template you fill in; the other is already filled in for this repo.
+
+| Prompt | Who it is for |
+| --- | --- |
+| **[BUILD-PROMPT.md](docs/BUILD-PROMPT.md)** | **Every adopter.** The generic multi-agent build prompt — fill in your project, taxonomy, and watch-list, then run it. |
+| **[SAW-VAULT-BUILD.md](docs/SAW-VAULT-BUILD.md)** | **This repo's maintainers.** Pre-scoped to {{PROJECT_SHORT}} and runnable as-is, with a ready-to-file ticket breakdown. |
+
+Start with the [Adoption Playbook](docs/ADOPTION-PLAYBOOK.md) if you want the steps around the
+prompt — what to run first, how to choose a taxonomy, and how to gate it in CI.
+
+## What This Is
+
+A **vault** is a bundle of small markdown concepts — one per real artifact or idea — each with
+structured frontmatter, each linking to its neighbours, each stamped with the commit its claims
+were verified at.
+
+Built on [Open Knowledge Format v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+(Google, Apache-2.0), which gives portability. This subsystem adds the rigor layer that gives
+trust: a strict frontmatter contract, a zero-dependency validator, an anti-hallucination link
+discipline, and a drift mechanism.
+
+**Why bother:** in the project this method came from, an independent architecture audit scored the
+vault *"the single strongest KT asset in the repo"* and told new developers to **trust it over the
+project's own canonical context file** — because the vault's claims were verified against a SHA
+and the canonical file's had silently drifted. Not that a vault is tidy. That it is checkable.
+
+## 30-Second Start
+
+```bash
+# 1. Prove the tooling works, against the bundle shipped here
+node knowledge-vault/scripts/validate-vault.mjs --vault knowledge-vault/templates/starter-bundle
+
+# 2. Copy the starter bundle to where your vault will live
+cp -r knowledge-vault/templates/starter-bundle docs/knowledge-vault
+
+# 3. Repoint canvas nodes at the new folder name.
+#    Canvas paths are Obsidian-vault-root-relative, so they move with the bundle.
+sed -i 's|"starter-bundle/|"knowledge-vault/|g' docs/knowledge-vault/maps/*.canvas
+
+# 4. Update bundle_root and obsidian_vault_root in _meta/vault-config.json, then re-validate
+node knowledge-vault/scripts/validate-vault.mjs --vault docs/knowledge-vault
+```
+
+The validator uses `node:` builtins only — no install step, no `package.json` required. It will
+tell you if you miss step 3 or 4: canvas nodes are checked, and a `bundle_root` that disagrees
+with where the vault actually sits raises a warning.
+
+## Contents
+
+```text
+knowledge-vault/
+├── docs/
+│   ├── GUIDE.md              # The method, and why each rule exists
+│   ├── ADOPTION-PLAYBOOK.md  # Steps, taxonomy choice, CI gating, ticket breakdown
+│   ├── BUILD-PROMPT.md       # (A) generic multi-agent build prompt
+│   ├── SAW-VAULT-BUILD.md    # (B) exact prompt for this repo's own vault
+│   └── OBSIDIAN-GUIDE.md     # Graph, canvases, Bases, and the config treaty
+├── templates/
+│   ├── starter-bundle/       # A working vault that validates clean as shipped
+│   ├── obsidian/             # app.json, graph.json, core-plugins.json
+│   └── github/               # Opt-in CI workflow
+└── scripts/
+    └── validate-vault.mjs    # Zero-dependency structural validator
+```
+
+## The Validator
+
+```bash
+node knowledge-vault/scripts/validate-vault.mjs --help
+```
+
+Enforces the frontmatter contract, exact section structure per type, link legality, that
+`resource`/`sources`/`docs` paths exist, that stub types cite their source, that canvas nodes
+point at real files, manifest/disk agreement, and orphan detection.
+
+**Wire it into CI.** `templates/github/validate-vault.yml` is ready to copy. In the reference
+project the validator existed, passed locally, and ran in **no** workflow — so drift was invisible
+until an audit caught it. That gap is documented here so you do not inherit it.
+
+## Maintenance
+
+The `vault-sync` skill ships with this harness (all four providers). It detects drift from
+`baseline_sha`, regenerates only what changed, validates, and records the sync.
+
+## Obsidian
+
+Optional but recommended — see the [Obsidian Guide](docs/OBSIDIAN-GUIDE.md). No community plugins
+required; the vault degrades gracefully to plain markdown in any editor. Bases views need Obsidian
+1.9+.
+
+Three settings are non-negotiable if you use it:
+
+```json
+{ "useMarkdownLinks": true, "newLinkFormat": "relative", "alwaysUpdateLinks": true }
+```
+
+Without them every link the GUI creates is a wikilink, and wikilinks fail validation.

--- a/knowledge-vault/README.md
+++ b/knowledge-vault/README.md
@@ -60,7 +60,9 @@ cp -r knowledge-vault/templates/starter-bundle docs/knowledge-vault
 
 # 3. Repoint canvas nodes at the new folder name.
 #    Canvas paths are Obsidian-vault-root-relative, so they move with the bundle.
-sed -i 's|"starter-bundle/|"knowledge-vault/|g' docs/knowledge-vault/maps/*.canvas
+#    (-i.bak keeps this portable: BSD/macOS sed requires a backup suffix.)
+sed -i.bak 's|"starter-bundle/|"knowledge-vault/|g' docs/knowledge-vault/maps/*.canvas \
+  && rm -f docs/knowledge-vault/maps/*.bak
 
 # 4. Update bundle_root and obsidian_vault_root in _meta/vault-config.json, then re-validate
 node knowledge-vault/scripts/validate-vault.mjs --vault docs/knowledge-vault

--- a/knowledge-vault/docs/ADOPTION-PLAYBOOK.md
+++ b/knowledge-vault/docs/ADOPTION-PLAYBOOK.md
@@ -1,0 +1,452 @@
+# Adoption Playbook
+
+**Purpose**: Take a team from "we merged the knowledge-vault subsystem" to "we have a vault our
+agents and our humans both trust, and CI fails when it drifts."
+
+**Audience**: The person running the first build. Assume one owner, a handful of agents, and a
+week of elapsed time.
+
+**Prerequisite**: Read [GUIDE.md](GUIDE.md) first. It explains *why* each rule exists. This
+document does not repeat the reasoning — it gives the order of operations and the decisions you
+have to make. Where the two disagree, GUIDE.md wins.
+
+Placeholders below use the repo's `{{TOKEN}}` convention. Replace them before running anything.
+
+---
+
+## Step 1 — Verify the tooling before you trust it
+
+The first thing you do after the PR merges is prove the validator works on a vault that is known
+to be clean. The starter bundle is that vault.
+
+```bash
+node knowledge-vault/scripts/validate-vault.mjs --vault knowledge-vault/templates/starter-bundle
+```
+
+Expected: a summary line, zero errors, exit code 0.
+
+```bash
+echo $?   # 0
+```
+
+If this does not exit 0, stop. Something about the merge is wrong, and every later step assumes a
+working validator. Check the CLI surface while you are here:
+
+```bash
+node knowledge-vault/scripts/validate-vault.mjs --help
+```
+
+| Flag | Use it when |
+| --- | --- |
+| `--vault <dir>` | Always. Auto-discovery only works when exactly one vault exists. |
+| `--allow-broken-links` | Mid-build, while concepts reference each other before all exist. Never in CI. |
+| `--strict-orphans` | Once navigation is built, to prove every concept is reachable. |
+| `--quiet` | In scripts, when you only want the summary line. |
+
+---
+
+## Step 2 — Copy the starter bundle
+
+Copy, do not symlink, and do not build directly inside `knowledge-vault/templates/`. The template
+stays pristine so you can diff against it later.
+
+```bash
+cp -r knowledge-vault/templates/starter-bundle {{VAULT_ROOT}}
+```
+
+`{{VAULT_ROOT}}` is repo-root-relative, for example `docs/vault` or `knowledge/bundle`.
+
+Then edit `{{VAULT_ROOT}}/_meta/vault-config.json`:
+
+| Field | Set it to | Why it matters |
+| --- | --- | --- |
+| `bundle_root` | `{{VAULT_ROOT}}` | The validator warns when this disagrees with where the vault actually is. |
+| `obsidian_vault_root` | the **parent** of `{{VAULT_ROOT}}` | Makes source-of-truth citations outside the bundle clickable in the GUI. |
+| `domains` | your business domains | Empty array disables the check; prefer real values. |
+| `tags` | your controlled vocabulary | Empty array disables the check; prefer real values. |
+
+Re-run the validator against the copy. It should still exit 0 — you now have a working vault of
+two concepts, which is the smallest thing that can drift.
+
+If you use Obsidian, apply the three settings from GUIDE.md's *GUI/validator treaty* now, before
+anyone creates a link by hand. Retrofitting wikilinks into markdown links is tedious.
+
+---
+
+## Step 3 — Choose your taxonomy
+
+Directories are three orthogonal axes, not one hierarchy. GUIDE.md's *three-axis taxonomy* section
+has the principle; this is the decision procedure.
+
+Ask three separate questions, and let each one produce its own directories:
+
+1. **Structural** — what artifacts does this repo actually contain? Mirror them.
+2. **Semantic** — what does the business call the parts of this product? Cross-cut them.
+3. **Conceptual** — what do we know that is not in any one file? Name those.
+
+### Worked example
+
+Take a hypothetical booking platform: a web front end, a job runner, a payments provider
+integration, a notifications provider integration, and an on-call rota.
+
+**Structural axis** — one directory per artifact class, mirroring the repo:
+
+| Directory | Holds |
+| --- | --- |
+| `services/` | Each deployable service, one concept per service |
+| `integrations/` | Each third-party provider the system talks to |
+| `operations/` | Environments, runbooks, deployment topology |
+| `interfaces/` | Public entry points — routes, endpoints, queues |
+
+**Semantic axis** — one directory, `domains/`, re-grouping the same artifacts by purpose:
+
+| Concept | Pulls together |
+| --- | --- |
+| `domains/booking.md` | The reservation service, the availability store, the booking routes |
+| `domains/billing.md` | The payments integration, the invoice job, the refund runbook |
+| `domains/messaging.md` | The notifications integration, the template store, the send job |
+
+Note what happened: `integrations/payments-provider.md` is a member of `domains/billing.md`, and it
+is written once and linked from both. The domain concept does not restate it.
+
+**Conceptual axis** — the knowledge that has no file:
+
+| Directory | Holds |
+| --- | --- |
+| `architecture/` | The service boundary decision, the data-flow model, the auth model |
+| `knowledge/` | Institutional facts: why the legacy queue is still there, what broke in the last incident |
+| `process/` | How work moves — including `process/vault-maintenance.md`, which ships in the bundle |
+
+**`domains/` is the axis teams forget.** It is also the one that decides whether the vault is
+usable. A newcomer does not ask "what is in `services/`" — they ask "how does billing work". If
+the only answer is a directory listing of artifacts, you have built a file browser with
+frontmatter. Budget real curation time for `domains/`: each domain concept is a hand-written
+`Members` list and a `Key Flows` narrative, and it is the highest-leverage writing in the vault.
+
+A useful sizing check: if you cannot name three to seven domains, you either have not talked to
+the people who sell the product, or your system is small enough that `domains/` can wait.
+
+---
+
+## Step 4 — Define your types
+
+Keep all 12 stack-agnostic types that ship in `vault-config.json`: `domain`, `architecture`,
+`integration`, `environment`, `runbook`, `process`, `pattern`, `adr`, `sop`, `agent-role`, `skill`,
+`guide`. They cost nothing if unused, and removing one is a config edit you can make later.
+
+Add a type when an artifact class has **a repeating shape** — the same questions get asked of every
+instance. If you cannot name the fixed sections, you do not have a type yet; you have a directory.
+
+Rules for every type you add:
+
+- Sections are **fixed and ordered**, and the last one is `Citations`.
+- Set `resource_required: true` when every instance maps to one primary file.
+- Set `stub: true` when the knowledge already lives in a source-of-truth document. The validator
+  then requires an out-of-bundle citation, which is what stops the concept quietly becoming a
+  second copy.
+- Add a matching template under `_meta/templates/` carrying per-section length budgets.
+
+### Worked example: adding a `job` type
+
+The booking platform runs scheduled jobs. Every job raises the same four questions: what does it
+do, when does it fire, what does it touch, what happens when it fails.
+
+Add to `types` in `{{VAULT_ROOT}}/_meta/vault-config.json`:
+
+```json
+"job": {
+  "sections": ["Overview", "Schedule & Trigger", "Data Touched", "Failure Modes", "Citations"],
+  "resource_required": true
+}
+```
+
+Then create `{{VAULT_ROOT}}/_meta/templates/job.md` with the length budgets inline:
+
+```markdown
+---
+type: job
+title: "{{JOB_NAME}}"
+description: "One sentence, under 160 chars, saying what this job does."
+resource: "{{PATH_TO_JOB_ENTRY_FILE}}"
+tags: [{{TAG}}]
+timestamp: {{YYYY-MM-DD}}
+status: active
+domain: {{DOMAIN}}
+verified_against: "{{SHORT_SHA}}"
+---
+
+# {{JOB_NAME}}
+
+## Overview
+
+2-4 sentences. What it does and why it exists. No implementation detail.
+
+## Schedule & Trigger
+
+2-4 bullets. Cadence, trigger mechanism, concurrency limits. Name config keys, never values.
+
+## Data Touched
+
+3-6 bullets. Stores read and written. Link to concepts by title; never link code files.
+
+## Failure Modes
+
+3-6 bullets. What fails, how it surfaces, which runbook responds. Link the runbook concept.
+
+## Citations
+
+Links to source-of-truth docs and external references only.
+```
+
+The budgets are not decoration. They are the mechanism that keeps a concept a map-card instead of a
+second copy of the code.
+
+Validate after every type you add — a typo in `sections` fails loudly and immediately:
+
+```bash
+node knowledge-vault/scripts/validate-vault.mjs --vault {{VAULT_ROOT}}
+```
+
+---
+
+## Step 5 — Run the build
+
+Open [BUILD-PROMPT.md](BUILD-PROMPT.md), fill in its placeholders, and run it. Four phases:
+
+| Phase | What you are doing | Done when |
+| --- | --- | --- |
+| **1 Extract** | Agents read source by artifact class and write fact digests into the manifest's `notes` | Every planned concept has a manifest entry with `notes` and a `batch` |
+| **2 Generate** | Fan out by batch; each agent gets the four-part prompt | Every manifest entry has a file on disk |
+| **3 Navigate** | Index cascade, `start-here.md`, canvases, Bases views | `--strict-orphans` passes |
+| **4 Verify** | Independent agents try to **refute** the claims | Every finding corrected, nothing outstanding |
+
+Two things to plan for rather than discover:
+
+- **Extraction before generation is not optional sequencing.** Generation agents work from the
+  digests, not from source. If `notes` is thin, the concepts will be thin, and you will not notice
+  until Phase 4.
+- **Run the validator with `--allow-broken-links` during Phases 1-3, and without it from Phase 4
+  on.** Mid-build, concepts legitimately reference siblings that do not exist yet. Once generation
+  is complete, a broken link is a defect.
+
+Phase 4 is where adopters are tempted to save time. Do not. On the reference build, 14 adversarial
+verifiers produced 25 evidence-backed findings, all corrected before the vault shipped. A vault
+nobody tried to falsify is a rumour with good formatting.
+
+---
+
+## Step 6 — Gate it
+
+A vault that is not gated decays silently. Two gates, both required before merge.
+
+```bash
+node knowledge-vault/scripts/validate-vault.mjs --vault {{VAULT_ROOT}} --strict-orphans
+{{MARKDOWN_LINT_COMMAND}}
+```
+
+Then wire the validator into CI:
+
+```bash
+cp knowledge-vault/templates/github/validate-vault.yml .github/workflows/
+```
+
+Edit the copied workflow so its vault path is `{{VAULT_ROOT}}`, commit it, and open a deliberately
+broken pull request — delete a linked concept, or point a `resource` at a path that does not
+exist — to confirm the check actually fails. A gate you have never seen go red is not a gate.
+
+**Be explicit with your team about why this step exists.** In the reference project the validator
+was written, it passed locally, and it was wired into **no** workflow. Drift was therefore
+invisible to CI, and an external architecture audit had to catch it. The tooling was fine; the
+wiring was missing. That is the failure mode this step exists to prevent, and it costs one file
+copy to avoid.
+
+Do not run CI with `--allow-broken-links`. It exists for mid-build only, and a CI job carrying it
+reports green on exactly the problems the validator was written to find.
+
+---
+
+## Step 7 — Maintain it
+
+The maintenance loop lives in `process/vault-maintenance.md` in the bundle and in the `vault-sync`
+skill. The loop:
+
+1. Compute drift: `git diff --name-only {{BASELINE_SHA}}..HEAD -- {{WATCH_LIST}}`
+2. A concept is stale **if and only if** a changed path matches its `resource` or its `sources`
+3. Re-derive the stale concepts **from source** — do not patch prose to match a changed API
+   without opening the file
+4. Bump `timestamp` and `verified_against` on what you actually re-verified, and only that
+5. Validate, prepend a dated entry to `log.md`, update `baseline_sha` in the manifest
+
+Two rules carry the loop:
+
+- **Deleted source becomes `status: deprecated`, never a deleted file.** Clean inbound links
+  first, in a follow-up change. Deleting immediately breaks the graph and the manifest.
+- **A citation is not re-verification.** Linking a concept from a new place does not make its
+  claims fresher. Only re-deriving it from source bumps `timestamp` and `verified_against`. Without
+  this rule, timestamps launder themselves and the falsifiability mechanism — the entire reason to
+  build a vault instead of a wiki — quietly stops meaning anything.
+
+Run the loop on a cadence that matches your merge rate. Weekly is a reasonable default; after any
+large refactor, immediately.
+
+---
+
+## File the work
+
+Copy the block below into your tracker. Replace `{{TICKET_PREFIX}}`, `{{VAULT_ROOT}}`,
+`{{PROJECT}}`, and `{{WATCH_LIST}}`. Story numbering assumes the epic is filed first.
+
+```text
+EPIC {{TICKET_PREFIX}}-100 — Build the {{PROJECT}} knowledge vault
+
+Goal
+Stand up an OKF knowledge vault for {{PROJECT}} at {{VAULT_ROOT}} whose staleness is computable,
+whose links are validated in CI, and whose claims have survived adversarial review.
+
+Scope
+In:  taxonomy, type catalog, extraction, generation, navigation, verification, CI gate.
+Out: rewriting existing source-of-truth docs. The vault links them; it does not replace them.
+
+Acceptance criteria
+- validate-vault.mjs --vault {{VAULT_ROOT}} --strict-orphans exits 0.
+- Markdown lint passes on {{VAULT_ROOT}}.
+- .github/workflows/validate-vault.yml runs the validator on every PR and has been observed to
+  fail on a deliberately broken PR.
+- manifest.json baseline_sha is a real short SHA; every concept has timestamp + verified_against.
+- Every Phase 4 verifier finding is either corrected or closed with a written rationale.
+
+Definition of done
+Epic closes only when all six stories are closed and the CI gate is required on the default branch.
+```
+
+```text
+STORY {{TICKET_PREFIX}}-101 — Scaffold the vault and prove the validator
+
+Description
+Copy the starter bundle to {{VAULT_ROOT}} and configure it for this repo. Establish that the
+validator runs clean before any content exists, so later failures are attributable to content.
+
+Acceptance criteria
+- validate-vault.mjs --vault knowledge-vault/templates/starter-bundle exits 0 (tooling proven).
+- {{VAULT_ROOT}} exists, copied from the starter bundle, template left unmodified.
+- vault-config.json: bundle_root = {{VAULT_ROOT}}; obsidian_vault_root = its parent directory.
+- validate-vault.mjs --vault {{VAULT_ROOT}} exits 0 with no bundle_root warning.
+- If Obsidian is used: useMarkdownLinks true, newLinkFormat relative, alwaysUpdateLinks true,
+  committed to the repo.
+
+Estimate: 1 point
+```
+
+```text
+STORY {{TICKET_PREFIX}}-102 — Define taxonomy and type catalog
+
+Description
+Decide the three-axis directory structure and the artifact types for this stack. Blocks all
+extraction and generation work.
+
+Acceptance criteria
+- Directory plan documented in the ticket, with each directory assigned to exactly one axis
+  (structural / semantic / conceptual).
+- domains/ is populated with 3-7 domains named in the language the business uses, each reviewed by
+  someone outside the authoring team.
+- vault-config.json: domains and tags set to real project vocabulary (no empty arrays).
+- Every added type declares fixed ordered sections ending in Citations; resource_required and stub
+  set deliberately, with the reason recorded in the ticket.
+- Every added type has a matching template in _meta/templates/ carrying per-section length budgets.
+- validate-vault.mjs --vault {{VAULT_ROOT}} exits 0 after config changes.
+
+Blocked by: {{TICKET_PREFIX}}-101
+Estimate: 3 points
+```
+
+```text
+STORY {{TICKET_PREFIX}}-103 — Phase 1: extract facts into the manifest
+
+Description
+Run extraction agents by artifact class. Output is fact digests in each manifest entry's notes
+field, not prose concepts. Generation reads these digests instead of re-reading source.
+
+Acceptance criteria
+- Every planned concept has a manifest entry with: id, type, title, path, description, tags, batch.
+- Every entry has a non-empty notes digest sourced from code, not from documentation.
+- Where code and docs disagree, the digest records the code behaviour and flags the discrepancy.
+- The manifest sources field maps source paths back to the concepts describing them.
+- baseline_sha is set to the real short SHA the extraction was run against.
+- No concept files written in this story. Extraction produces digests only.
+
+Blocked by: {{TICKET_PREFIX}}-102
+Estimate: 5 points
+```
+
+```text
+STORY {{TICKET_PREFIX}}-104 — Phase 2: generate concepts
+
+Description
+Fan out generation agents by batch. Every agent prompt carries exactly four inputs: the type
+template, a golden example of the same type, the hard rules inline, and the manifest ID registry
+as the link allowlist.
+
+Acceptance criteria
+- Every manifest entry has a corresponding file on disk; no file exists outside the manifest.
+- Every concept: exactly one H1, H2 set exactly matching its type template, ends in Citations.
+- Every concept carries timestamp and verified_against.
+- Every link resolves to a manifest ID. Zero invented links.
+- Stub-typed concepts each cite an out-of-bundle source-of-truth document.
+- No concept exceeds the max_concept_lines budget without a recorded justification.
+- validate-vault.mjs --vault {{VAULT_ROOT}} exits 0 without --allow-broken-links.
+
+Blocked by: {{TICKET_PREFIX}}-103
+Estimate: 8 points
+```
+
+```text
+STORY {{TICKET_PREFIX}}-105 — Phase 4: adversarial verification
+
+Description
+Independent agents attempt to REFUTE the vault's claims. Verifiers must not have authored the
+concepts they review. Confirmation is not the deliverable; evidence is.
+
+Acceptance criteria
+- Each verifier covers a defined slice and reports findings with file:line or a reproduced command.
+- Findings without evidence are rejected and re-run.
+- Every finding is triaged as wrong / minor / not-a-defect, with a one-line rationale.
+- Every wrong and minor finding is corrected in the vault before this story closes.
+- Concepts changed by a correction have timestamp and verified_against re-stamped.
+- Finding count, triage split, and resolution recorded in the ticket for the next build to compare.
+
+Blocked by: {{TICKET_PREFIX}}-104
+Estimate: 5 points
+```
+
+```text
+STORY {{TICKET_PREFIX}}-106 — Phase 3 + CI: navigation and the gate
+
+Description
+Build both doors — reference and learning — then wire the validator into CI so drift cannot land
+silently.
+
+Acceptance criteria
+- Index cascade complete: root index links section indexes, section indexes link concepts, every
+  link annotated rather than bare.
+- start-here.md is an ordered path where every step states WHY it comes at that position, ending in
+  one traced vertical slice: entry point -> handler -> the store it writes.
+- At least one canvas and one saved view exist; canvas nodes reference files that exist.
+- validate-vault.mjs --vault {{VAULT_ROOT}} --strict-orphans exits 0 (zero orphans).
+- knowledge-vault/templates/github/validate-vault.yml copied to .github/workflows/ and pointed at
+  {{VAULT_ROOT}}. The workflow does NOT pass --allow-broken-links.
+- A deliberately broken PR was opened and the check was observed failing; link to that PR.
+- The check is marked required on the default branch.
+- process/vault-maintenance.md reflects this project's {{WATCH_LIST}} and sync cadence.
+
+Blocked by: {{TICKET_PREFIX}}-105
+Estimate: 5 points
+```
+
+---
+
+## Related Reading
+
+- [Knowledge Vault Guide](GUIDE.md) — the method and the reasoning behind each rule
+- [Build Prompt](BUILD-PROMPT.md) — the runnable multi-agent build
+- [Conventions](../templates/starter-bundle/_meta/CONVENTIONS.md) — the constitution
+- [Contributing](../../CONTRIBUTING.md) — branch, commit, and PR requirements for this repo

--- a/knowledge-vault/docs/BUILD-PROMPT.md
+++ b/knowledge-vault/docs/BUILD-PROMPT.md
@@ -1,0 +1,333 @@
+# Build Prompt
+
+**Purpose**: The generic, parameterized multi-agent prompt for building a knowledge vault from an
+existing codebase. This is the thing you paste into an orchestrator.
+
+**Audience**: Whoever is running the build. Read [GUIDE.md](GUIDE.md) for why the rules are what
+they are, and [ADOPTION-PLAYBOOK.md](ADOPTION-PLAYBOOK.md) for what happens before and after this
+document. This file is the runnable middle.
+
+**What this produces**: a bundle of ~50-line concepts under `{{VAULT_ROOT}}`, one per real
+artifact or idea, each with structured frontmatter, each linked into a navigable graph, each
+stamped with the commit its claims were checked against — plus the two navigation doors and a
+green validator run. The reference build produced 227 concepts through these four phases.
+
+---
+
+## Fill these in first
+
+The build will not work with placeholders left in. Resolve every one before Phase 1.
+
+| Token | Meaning | Example |
+| --- | --- | --- |
+| `{{PROJECT}}` | The system being documented | `booking-platform` |
+| `{{VAULT_ROOT}}` | Repo-root-relative path to the bundle | `docs/vault` |
+| `{{REPO_ROOT}}` | Absolute path to the repository | `/work/booking-platform` |
+| `{{BASELINE_SHA}}` | Short SHA the build is run against | output of `git rev-parse --short HEAD` |
+| `{{WATCH_LIST}}` | Paths whose changes can make concepts stale | `src/ config/ docs/ migrations/` |
+| `{{TAXONOMY}}` | The directory plan, one line per directory + its axis | see the playbook |
+| `{{TYPE_CATALOG}}` | The `types` block from `vault-config.json` | see the playbook |
+| `{{MARKDOWN_LINT_COMMAND}}` | This repo's markdown lint invocation | project-specific |
+
+Prerequisites: the vault is scaffolded, `vault-config.json` reflects `{{TAXONOMY}}` and
+`{{TYPE_CATALOG}}`, and every type has a template under `_meta/templates/`.
+
+Throughout Phases 1-3, validate with `--allow-broken-links`. Drop that flag from Phase 4 onward.
+
+---
+
+## Phase 1 — Extract
+
+**Goal**: turn source code into pre-digested facts, so generation agents never have to re-read the
+repository. Output is manifest entries — `notes` digests plus a `batch` lane — not prose.
+
+**Fan-out**: one agent per artifact class in `{{TAXONOMY}}`. Services, integrations, interfaces,
+operations, jobs, and so on. Agents run in parallel and write disjoint sets of manifest entries.
+
+**Why digests come first**: a generation agent handed raw source will summarize what it happens to
+read. A generation agent handed a digest writes about what the extraction agent decided mattered.
+The second is consistent across hundreds of files; the first is not. Thin digests produce thin
+concepts, and you will not find out until Phase 4.
+
+### Extraction agent prompt
+
+````text
+You are an extraction agent for the {{PROJECT}} knowledge vault. You are documenting the artifact
+class: {{ARTIFACT_CLASS}}.
+
+Your job is to gather FACTS. You are not writing concepts. Do not write any .md file.
+
+INPUTS
+- Repository root: {{REPO_ROOT}}
+- Source paths in scope: {{SCOPE_PATHS}}
+- The vault config: {{VAULT_ROOT}}/_meta/vault-config.json
+- The current manifest: {{VAULT_ROOT}}/_meta/manifest.json
+
+TASK
+1. Enumerate every real artifact of class {{ARTIFACT_CLASS}} under {{SCOPE_PATHS}}. One artifact =
+   one planned concept. Do not invent artifacts. Do not merge two real artifacts into one entry.
+2. For each artifact, read the actual implementation. Read the entry file and the files it calls
+   into. Do not stop at the module's own documentation.
+3. Write one manifest entry per artifact into {{VAULT_ROOT}}/_meta/manifest.json with these fields:
+     id           bundle-relative path minus .md, kebab-case
+     type         one of the types declared in vault-config.json
+     title        human title, matches the H1 the generator will write
+     path         id + ".md"
+     description  one sentence, under 160 characters
+     tags         from the controlled vocabulary in vault-config.json only
+     domain       from the domains list in vault-config.json, when one applies
+     sources      every source path whose change should make this concept stale
+     batch        "{{BATCH_NAME}}"
+     notes        the fact digest — see below
+4. Set baseline_sha to {{BASELINE_SHA}} if it is not already set.
+
+THE NOTES DIGEST — this is the deliverable
+Pipe-separated facts, dense, no prose, no hedging. Cover: what the artifact does, what it calls,
+what calls it, what data it touches, which configuration keys it reads, and how it fails.
+Name the helper ACTUALLY called, not the one that should be called.
+
+Example shape:
+  notes: "entry at src/x/handler.ts | validates via schema in src/x/schema.ts | writes table
+  bookings | reads config KEY_A KEY_B | retries 3x then dead-letters | called by the scheduler,
+  never by a route"
+
+HARD RULES
+- CODE WINS OVER DOCS. Where implementation contradicts documentation, record the implementation
+  and add a "DOC DRIFT:" clause to the digest naming both sides. Do not silently pick one.
+- Configuration KEY NAMES may be recorded. Configuration VALUES never may, including defaults that
+  look harmless.
+- If you cannot determine a fact from source, write "UNKNOWN: <question>" in the digest. Do not
+  guess, and do not omit the gap silently.
+- Every path you record in sources must exist on disk. The validator checks this.
+
+OUTPUT
+The updated manifest, plus a short report: artifacts found, entries written, every UNKNOWN, and
+every DOC DRIFT clause.
+````
+
+**Phase 1 exit criteria**: every planned concept has a manifest entry with a non-empty `notes`
+digest and a `batch`; `baseline_sha` is a real SHA; no `.md` concept files have been written.
+
+---
+
+## Phase 2 — Generate
+
+**Goal**: turn digests into concepts. Fan out by `batch` — each generation agent takes one lane and
+writes every concept in it.
+
+**The key detail**: every generation agent prompt carries **exactly four things**, and dropping any
+one has a predictable failure mode.
+
+| Input | What it is | What its absence causes |
+| --- | --- | --- |
+| **Type template** | The frontmatter stencil and fixed section list from `_meta/templates/` | Structurally invalid files; validator fails on H2 sets |
+| **Golden example** | One real, already-accepted concept of the same type | Drift — every agent invents its own voice and depth |
+| **Hard rules inline** | The constitution, pasted in full, not linked | Hedging, duplication, aspirational claims |
+| **Manifest ID registry** | The concept ID list, as a link allowlist | Invented links — confident references to files nobody wrote |
+
+Template alone yields structurally-correct emptiness. Example alone yields drift. Rules alone yield
+hedging. All four together yield concepts that read as though one author wrote them.
+
+The golden example is the input teams skip because it feels redundant next to the template. It is
+not. Write one concept by hand, accept it, and use it as the example for its whole type.
+
+### Generation agent prompt
+
+````text
+You are a generation agent for the {{PROJECT}} knowledge vault. You are writing batch
+{{BATCH_NAME}} — the concepts listed at the end of this prompt.
+
+You have four inputs. Use all four. Do not go looking for a fifth.
+
+INPUT 1 — TYPE TEMPLATE
+{{PASTE_THE_FULL_TEMPLATE_FROM__meta/templates/<type>.md}}
+The H2 sections are FIXED and ORDERED. Do not add, remove, rename, or reorder them. The per-section
+length budgets in the template are limits, not suggestions.
+
+INPUT 2 — GOLDEN EXAMPLE
+{{PASTE_ONE_REAL_ACCEPTED_CONCEPT_OF_THE_SAME_TYPE}}
+Match its voice, its density, and its level of abstraction. When the template and the example
+disagree on shape, the template wins on structure and the example wins on tone.
+
+INPUT 3 — HARD RULES
+- Exactly one H1 (the title). Every section is an H2. The last H2 is "Citations".
+- Frontmatter required: type, title, description (one sentence, <=160 chars), tags, timestamp,
+  status. Also stamp: verified_against: "{{BASELINE_SHA}}" and timestamp: {{BUILD_DATE}}.
+- YAML subset only: scalars, double-quoted strings, inline lists [a, b], two-space block lists.
+  No nested maps. No multiline scalars. The validator parses without a YAML library.
+- tags come from the controlled vocabulary in vault-config.json. domain comes from its domains
+  list. Nothing else validates.
+- SUMMARIZE, NEVER DUPLICATE. If you are restating more than a paragraph of a source document,
+  stop and link to it instead. The concept is a map-card, not a copy.
+- CODE WINS OVER DOCS. Name the helper actually called, not the one that should be called. If the
+  digest carries a DOC DRIFT clause, state the real behaviour and note the discrepancy in one
+  sentence.
+- Configuration key NAMES may appear. Configuration VALUES never may.
+- Links: relative markdown only. No wikilinks. No leading-slash paths. No repository-host URLs for
+  files in this repo. Code files are never linked — name them as inline code, or carry them in
+  resource / sources.
+- Links that leave the bundle appear ONLY under "## Citations".
+- Stay under the max_concept_lines budget in vault-config.json.
+- No emoji.
+- If the digest says UNKNOWN, write the gap into the concept as an explicit open question. Do not
+  fill it with a plausible guess.
+
+INPUT 4 — ID REGISTRY (LINK ALLOWLIST)
+{{PASTE_THE_LIST_OF_EVERY_id_IN_manifest.json}}
+LINK ONLY TO IDS ON THIS LIST. This is an allowlist, not a suggestion. If you want to link to a
+concept that is not listed, name it in prose WITHOUT a link and report it as a suggestion at the
+end of your run. NEVER INVENT LINKS. A plausible-looking broken link is worse than no link,
+because it survives review.
+
+YOUR ASSIGNMENT
+{{PASTE_THE_MANIFEST_ENTRIES_FOR_THIS_BATCH_INCLUDING_THEIR_notes_DIGESTS}}
+Write facts from the notes digests. Do not re-read source to add facts the digest omitted; report
+the omission instead.
+
+OUTPUT
+One file per assigned entry at its manifest path, plus a report listing: files written, every
+suggested-but-unlinkable concept, and every digest gap you could not resolve.
+````
+
+**Phase 2 exit criteria**: every manifest entry has a file, and every file is in the manifest;
+`validate-vault.mjs --vault {{VAULT_ROOT}}` exits 0 **without** `--allow-broken-links`.
+
+---
+
+## Phase 3 — Navigate
+
+**Goal**: build both doors. A vault needs a reference door and a learning door, and they are not
+the same document.
+
+### The index cascade
+
+Root `index.md` links section indexes; section indexes link concepts. `index.md` files carry no
+frontmatter — the root is the single exception, and it declares `okf_version`.
+
+Every link is annotated. A bare list of titles is a directory listing; the annotation is the
+curation, and it is the reason a reader picks one link over another.
+
+### `start-here.md`
+
+An ordered path where **every step states why it comes at that position**. The WHY clause is the
+teaching. "Read the security model third" is a table of contents. "Read it third because
+everything after this assumes it, and it is the one convention you cannot violate even once" is
+onboarding.
+
+End it with **one traced vertical slice**: a single request or job followed from entry point, to
+handler, to the store it writes — every hop linked to a real concept. One concrete path through
+the system beats any amount of overview, because the reader can check it against the code.
+
+### Canvases and views
+
+- **Canvases** — spatial maps for relationships a linear document cannot show: a domain and its
+  members, a request lifecycle, a deployment topology. Canvas node paths are resolved against the
+  Obsidian vault root, so they only work if `obsidian_vault_root` is set correctly.
+- **Bases views** — saved queries over frontmatter. The ones that earn their keep: concepts by
+  `status`, concepts by `domain`, and concepts whose `verified_against` is behind `baseline_sha`.
+  The last one is the drift dashboard.
+
+**Phase 3 exit criteria**: `validate-vault.mjs --vault {{VAULT_ROOT}} --strict-orphans` exits 0.
+Zero orphans means every concept is reachable from a door.
+
+---
+
+## Phase 4 — Verify (adversarial)
+
+**Goal**: try to break the vault. Verifiers are **independent** — an agent does not verify a batch
+it generated — and their job is to **refute** claims, not to confirm them.
+
+Frame the task as refutation because confirmation bias is the whole problem. An agent asked "is
+this concept accurate?" will read the concept, find it coherent, and say yes. An agent asked "prove
+this claim wrong" opens the file.
+
+**Evidence is the deliverable.** Every finding carries `file:line` or a command that was actually
+run with its actual output. A finding without evidence is not a finding and gets re-run.
+
+On the reference build, 14 adversarial verifiers produced 25 evidence-backed findings — 9 outright
+wrong, 16 minor — and every one was corrected before the vault shipped.
+
+### Verifier agent prompt
+
+````text
+You are an adversarial verifier for the {{PROJECT}} knowledge vault. You did not write these
+concepts. Your job is to prove them WRONG.
+
+SCOPE
+{{LIST_OF_CONCEPT_FILES_TO_VERIFY}}
+
+STANCE
+Assume each concept contains an error and find it. You are not reviewing for style, tone, or
+completeness. You are looking for claims that are FALSE about the code as it exists at
+{{BASELINE_SHA}}. Do not report that a concept is "good" — that is not an output.
+
+METHOD
+For each concept, for each factual claim:
+1. Open the file named in resource or sources. Read the implementation. Do not read the concept's
+   own citations and stop there.
+2. Check specifically for:
+   - A named helper, function, module, or table that does not exist, or is not the one called
+   - A described control flow that the code does not follow
+   - A stated failure or retry behaviour the code does not implement
+   - A configuration key that is not read where the concept says it is read
+   - A claim that matches the DOCUMENTATION but contradicts the CODE (code wins; this is a finding)
+   - A link whose target concept does not describe what the link text implies
+   - A stub-typed concept that restates its source instead of citing it
+   - resource / sources paths that do not exist on disk
+3. Where a claim is testable by running something, run it and record the real output.
+
+EVIDENCE REQUIREMENT
+Every finding MUST carry either:
+   file:line   e.g. src/x/handler.ts:142 — the concept says it retries; the code throws
+   a command   the exact command you ran and its actual output, pasted
+Findings without evidence are rejected and re-run. Do not infer, do not reason from naming, and do
+not report a suspicion as a finding.
+
+SEVERITY
+   wrong  — the claim is false and would mislead a reader into an incorrect action
+   minor  — imprecise, incomplete, or stale wording that does not mislead
+Report the count of each. Do not inflate severity to look thorough.
+
+OUTPUT
+A findings list. Each entry: concept id, claim quoted verbatim, evidence, severity, and the
+corrected wording you propose. If you found nothing in a concept after actually opening its
+sources, say so explicitly and name the files you opened.
+````
+
+### Closing the phase
+
+Every finding is triaged as wrong / minor / not-a-defect with a one-line rationale. Every wrong and
+minor finding is **corrected before merge** — findings that ship as a backlog item are findings
+that never get fixed. Concepts changed by a correction get `timestamp` and `verified_against`
+re-stamped, because they were genuinely re-derived from source.
+
+Record the finding count and triage split. The next build compares against it.
+
+**Phase 4 exit criteria**: zero outstanding findings; validator and markdown lint both pass without
+softening flags.
+
+---
+
+## The non-negotiables
+
+The checklist. If a build is going wrong, it is almost always one of these.
+
+- [ ] **Link only to manifest IDs.** The manifest is an allowlist. A concept you want but do not
+      have gets named in prose without a link and reported as a suggestion. Never invent links.
+- [ ] **Stub, don't duplicate.** If the knowledge lives in a source-of-truth document, the concept
+      is a map-card that cites it. Restating more than a paragraph means stop and link.
+- [ ] **Code wins over docs.** Name the helper actually called. When code and documentation
+      disagree, record the code and note the discrepancy.
+- [ ] **Stamp `verified_against` and `timestamp`.** Both, on every concept, on every re-derivation.
+      And a citation is not re-verification — only re-reading the source bumps them.
+- [ ] **Validator and markdown lint must pass.** `validate-vault.mjs --vault {{VAULT_ROOT}}
+      --strict-orphans` and `{{MARKDOWN_LINT_COMMAND}}`, both clean, with no `--allow-broken-links`
+      after Phase 3.
+
+---
+
+## Related Reading
+
+- [Knowledge Vault Guide](GUIDE.md) — the method and the reasoning
+- [Adoption Playbook](ADOPTION-PLAYBOOK.md) — scaffolding, taxonomy, CI gate, maintenance
+- [Conventions](../templates/starter-bundle/_meta/CONVENTIONS.md) — the constitution in full

--- a/knowledge-vault/docs/GUIDE.md
+++ b/knowledge-vault/docs/GUIDE.md
@@ -1,0 +1,238 @@
+# Knowledge Vault Guide
+
+**Purpose**: Explain the OKF knowledge-vault method — what it is, why each rule exists, and how a
+knowledge base stays true as the code moves under it.
+
+**Audience**: Anyone adopting the harness who wants their agents and their humans working from the
+same map.
+
+**Core belief**: A knowledge base that cannot be proven stale will become confidently wrong, and
+confidently wrong is worse than absent. Everything below serves making staleness **computable**.
+
+---
+
+## What This Is
+
+A **vault** is a bundle of small markdown concepts — one per real artifact or idea — each carrying
+structured frontmatter, each linking to its neighbours, and each recording the commit its claims
+were checked against.
+
+It is a **map, not the territory**. Source-of-truth documents stay where they live. Code stays
+authoritative over everything, including the vault. A concept is a ~50-line map-card that
+summarizes and links; it never restates its source.
+
+Built on [Open Knowledge Format v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+(Google, Apache-2.0) — an open spec for portable markdown knowledge bundles. OKF requires only a
+`type` field and keeps conformance deliberately loose so that consumers never reject a bundle.
+
+**This harness adds the rigor layer on top**: a strict frontmatter contract, a zero-dependency
+validator, an anti-hallucination link discipline, and the verification mechanism that makes the
+whole thing falsifiable. OKF gives portability. The rules below give trust.
+
+---
+
+## Why Bother
+
+The honest case, from the project this method came from: an independent architecture audit of that
+codebase scored twelve dimensions and found documentation to be one of the weak ones — **except**
+for the vault, which it recorded as *"the single strongest KT asset in the repo"* and instructed
+new developers to **trust over the project's own canonical `CLAUDE.md`**, because the vault's
+version claims were verified against a SHA and the canonical file's had silently drifted.
+
+That is the whole argument. Not that a vault is tidy — that it is **checkable**, and therefore
+beats hand-maintained prose the moment the two disagree.
+
+---
+
+## The Eight Ideas
+
+### 1. Two-level falsifiability: `verified_against` and `baseline_sha`
+
+Every concept records `verified_against` — the git SHA at which its claims were checked — and
+`timestamp`, the date of that check. The manifest records `baseline_sha`: the commit the vault as
+a whole was last verified against.
+
+Drift is then a computation, not a feeling:
+
+```bash
+git diff --name-only "$BASELINE"..HEAD -- <watch-list>
+```
+
+A concept is stale **if and only if** a changed path matches its `resource` or one of its
+`sources`. File-level truth. Not "docs older than 90 days", which flags everything and teaches
+people to ignore the flag.
+
+**And the discipline that keeps it honest: a citation is not re-verification.** Linking a concept
+from somewhere new does not make its claims fresher. Only re-deriving it from source bumps the
+pair. Without this rule, timestamps launder themselves and the whole mechanism rots.
+
+### 2. The anti-hallucination link rule
+
+> Link only to concept IDs listed in the manifest. If a concept you want does not exist, name it
+> in prose without a link and report it as a suggestion. **Never invent links.**
+
+The manifest is an **allowlist**. This single rule is what makes it possible to generate hundreds
+of concepts with dozens of parallel agents and get a coherent graph out, rather than a web of
+plausible-looking links to files nobody wrote. An agent asked to "link related concepts" will
+otherwise produce beautiful, confident, broken references.
+
+### 3. The four-part generation prompt
+
+Every generation agent gets exactly four things:
+
+1. **The type template** — the frontmatter stencil and the fixed section list
+2. **A golden example** — one real, already-accepted concept of the same type
+3. **The hard rules** — the constitution, inline
+4. **The ID registry** — the manifest, as the link allowlist
+
+Template alone yields structurally-correct emptiness. Example alone yields drift. Rules alone
+yield hedging. All four together yield concepts that look like one author wrote them.
+
+### 4. Stub, don't duplicate
+
+If the knowledge already lives in a source-of-truth document, the concept is a map-card that cites
+it — an abstract, the links that place it in the system, and nothing more.
+
+> If you are restating more than a paragraph, stop and link.
+
+Types flagged `stub` in the config are validated for this: they must carry an out-of-bundle
+citation. A stub that restates its source is now two things to maintain, and they will diverge.
+
+### 5. Code wins over docs
+
+> Name the helper actually called, not the one the code *should* call. When code contradicts
+> documentation, the code wins and the discrepancy is noted.
+
+This is what makes a vault worth reading. Aspirational documentation is the default failure mode
+of every knowledge base; a concept that records a deliberate deviation — and says it is one — is
+more valuable than one describing the intended design.
+
+### 6. The three-axis taxonomy
+
+Directories are not one hierarchy but three orthogonal ones:
+
+| Axis | Organizes by | Example dirs |
+| --- | --- | --- |
+| **Structural** | real artifacts, mirroring the repo | `lib/`, `integrations/`, `operations/` |
+| **Semantic** | business domain — a curated cross-cut | `domains/` |
+| **Conceptual** | cross-cutting views and institutional knowledge | `architecture/`, `knowledge/` |
+
+The semantic axis is the one people forget, and the one that makes a vault navigable **by intent**
+rather than by file location. A newcomer does not ask "what is in `lib/`" — they ask "how does
+billing work". `domains/` answers that by re-grouping artifacts around purpose.
+
+### 7. The GUI/validator treaty
+
+If you use Obsidian, three settings are non-negotiable:
+
+```json
+{ "useMarkdownLinks": true, "newLinkFormat": "relative", "alwaysUpdateLinks": true }
+```
+
+Without them, every link the GUI creates is a wikilink, and wikilinks fail validation. With them,
+the editor and the validator want the same thing, and renaming a note rewrites its inbound links
+automatically. Three lines that decide whether the tooling fights you.
+
+### 8. Two-door navigation
+
+A vault needs a **reference** door and a **learning** door, and they are not the same document.
+
+- `index.md` — the cascade. Root index links section indexes link concepts. Curated, annotated,
+  browsable. For people who know what they are looking for.
+- `start-here.md` — an ordered path where **every step states why it comes there**, ending in one
+  traced vertical slice: an entry point, to the handler, to the store it writes.
+
+That WHY clause is the teaching. "Read the security model third" is a table of contents; "read it
+third because everything after assumes it, and it is the one convention you cannot violate even
+once" is onboarding.
+
+---
+
+## How a Vault Gets Built
+
+Four phases, run as a multi-agent pipeline. The reference build produced 227 concepts this way.
+
+| Phase | What it does | Output |
+| --- | --- | --- |
+| **Extract** | Read source, gather facts per artifact class | Fact digests into the manifest's `notes` |
+| **Generate** | Fan out by batch, four-part prompt each | Concepts |
+| **Navigate** | Build the doors | Indexes, `start-here.md`, canvases, views |
+| **Verify** | Independent agents try to **break** each claim | Findings — all corrected before merge |
+
+The verify phase is not optional polish. On the reference build, 14 adversarial verifiers produced
+25 evidence-backed findings — 9 outright wrong, 16 minor — every one corrected before the vault
+shipped. A knowledge base nobody tried to falsify is a rumour with good formatting.
+
+See [BUILD-PROMPT.md](BUILD-PROMPT.md) for the runnable version.
+
+---
+
+## How a Vault Stays True
+
+The `vault-sync` skill encodes the maintenance loop: detect drift from `baseline_sha`, detect
+inventory changes, regenerate **only** what drifted, validate, record.
+
+Two rules do the heavy lifting:
+
+- **Deleted source → `status: deprecated`, never file deletion.** Inbound links must be cleaned
+  first, in a follow-up change. Deleting immediately breaks the graph.
+- **Re-derive from source; never patch prose without re-reading the code it describes.** Editing a
+  concept to match a changed API without opening the file is how a vault becomes fiction.
+
+---
+
+## The Validator
+
+`scripts/validate-vault.mjs` — zero dependencies, `node:` builtins only, so it runs anywhere Node
+runs with no install step.
+
+It enforces: the frontmatter contract, exact section structure per type, link legality (no
+wikilinks, no leading-slash paths, no repository-host URLs for repo files), that `resource` /
+`sources` / `docs` paths actually exist, that stub types cite their source, that canvas nodes
+reference real files, manifest/disk agreement in both directions, and orphan detection.
+
+```bash
+node knowledge-vault/scripts/validate-vault.mjs --vault path/to/your/vault
+```
+
+Exit 0 means no errors; warnings are allowed. `--strict-orphans` promotes orphan warnings to
+errors. `--allow-broken-links` softens link and manifest errors during an early build — use it
+while building, never in CI.
+
+**Wire it into CI.** An opt-in workflow template ships at
+`knowledge-vault/templates/github/validate-vault.yml`. This matters: in the reference project the
+validator existed, passed locally, and was wired into **no** workflow — so drift was invisible to
+CI, and an audit had to catch it. Do not inherit that gap.
+
+---
+
+## Adapting It To Your Project
+
+The 12 types shipped in the starter config are **stack-agnostic**: `domain`, `architecture`,
+`integration`, `environment`, `runbook`, `process`, `pattern`, `adr`, `sop`, `agent-role`, `skill`,
+`guide`.
+
+Types for *your* artifacts are yours to define. A web application might add:
+
+```json
+"api-endpoint": {
+  "sections": ["Overview", "Auth & Access", "Request & Response",
+               "Data Access", "Patterns Applied", "Citations"],
+  "resource_required": true
+}
+```
+
+A data platform might add `pipeline` or `dataset`. A mobile app, `screen` or `feature-module`.
+The rule is the same in every case: **fixed sections, ordered, ending in `Citations`**, with a
+matching template that carries per-section length budgets ("2-4 sentences", "3-6 bullets"). Those
+budgets are what stop concepts sprawling back into duplication.
+
+---
+
+## Related Reading
+
+- [Adoption Playbook](ADOPTION-PLAYBOOK.md) — run your first build
+- [Build Prompt](BUILD-PROMPT.md) — the generic multi-agent build prompt
+- [Conventions](../templates/starter-bundle/_meta/CONVENTIONS.md) — the constitution
+- [Obsidian Guide](OBSIDIAN-GUIDE.md) — graph, canvases, and Bases
+- [OKF Specification](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)

--- a/knowledge-vault/docs/OBSIDIAN-GUIDE.md
+++ b/knowledge-vault/docs/OBSIDIAN-GUIDE.md
@@ -1,0 +1,176 @@
+# Obsidian Guide
+
+**Purpose**: Set up [Obsidian](https://obsidian.md) as the visual layer over a knowledge vault —
+graph, canvases, and Bases — and explain the configuration that makes the editor and the validator
+want the same thing.
+
+**Audience**: Anyone maintaining a vault who wants to see it, not just read it.
+
+**Optional**: The vault is plain markdown and works in any editor, in `git`, and on the web.
+Obsidian adds a graph, spatial canvases, and live database views. Nothing here is required.
+
+---
+
+## The Config Treaty
+
+Three settings decide whether your tooling helps you or fights you:
+
+```json
+{
+  "useMarkdownLinks": true,
+  "newLinkFormat": "relative",
+  "alwaysUpdateLinks": true
+}
+```
+
+- `useMarkdownLinks: true` — Obsidian creates `[text](path.md)`, not `[[wikilinks]]`. **Wikilinks
+  fail validation**, and the default is wikilinks, so without this every link you create by
+  clicking is a future CI failure.
+- `newLinkFormat: "relative"` — matches the relative-links-only rule.
+- `alwaysUpdateLinks: true` — renaming a concept rewrites every inbound link automatically.
+
+Copy `knowledge-vault/templates/obsidian/app.json` into your vault's `.obsidian/` and adjust the
+paths. This is the single highest-value configuration in the system.
+
+---
+
+## Vault Root: Point It at the Parent
+
+Open Obsidian on the **parent** of your bundle, not the bundle itself.
+
+If your vault lives at `docs/knowledge-vault/`, open `docs/` as the Obsidian vault.
+
+Why it matters:
+
+1. **Citations stay clickable.** Concepts cite source-of-truth documents that live outside the
+   bundle. With the wider root, those are live links with hover previews. With the narrow root,
+   every citation is a dead path.
+2. **The graph shows map and territory**, with a colour group greying out everything outside the
+   bundle — instant visual separation.
+3. **Bases filters need it.** Every `.base` file filters with `file.inFolder("<bundle>")`, which
+   only makes sense if the vault is a superset of the bundle.
+4. **Search spans both**, so "where is this documented" finds the source and the map-card together.
+
+Use `userIgnoreFilters` in `app.json` to hide the noise the wider root pulls in — archives,
+generated reports, and the `_meta/templates/` directory, which would otherwise pollute search.
+
+---
+
+## The Graph
+
+`templates/obsidian/graph.json` ships colour groups keyed to directory, plus tuned physics
+(`linkDistance: 250`, `repelStrength: 12`, labels always visible).
+
+The important group is the last one:
+
+```json
+{ "query": "-path:starter-bundle", "color": { "a": 1, "rgb": 8947848 } }
+```
+
+Everything outside the bundle greys out. Map and territory become visually distinct at a glance.
+
+`showOrphans` is deliberately **true**. An orphan — a concept nothing links to — is a defect you
+want to see, not hide. The validator reports them too.
+
+---
+
+## Canvases
+
+Canvases use the [JSONCanvas](https://jsoncanvas.org) open spec: a JSON file of `nodes` and
+`edges`. Nodes of `type: "file"` embed a real concept, rendered as a live card you can click
+straight through.
+
+**They are not separate diagrams.** They are spatial layouts over the same concept files, so they
+cannot drift into being a second thing to maintain. The validator checks that every `file` node
+points at something real.
+
+Two genres, one example of each in the starter bundle:
+
+| Genre | Shape | Example |
+| --- | --- | --- |
+| **Architectural** | Labelled columns at a fixed pitch, one card per load-bearing concept, stable over time | `maps/system-overview.canvas` |
+| **Flow** | Mostly file nodes, edge-dense, tracing one path end to end | `maps/vault-lifecycle.canvas` |
+
+A third genre is worth knowing: the **report** canvas — a dated, point-in-time artifact such as an
+audit heatmap, where node colour encodes a verdict and edges wire each finding to the concepts
+that must change. It renders an assessment *into* the knowledge graph rather than beside it.
+
+Keep one canvas per major flow, and link it from the relevant domain hub and from `start-here.md`.
+
+### Canvas paths move with the bundle
+
+Node `file` paths are **Obsidian-vault-root-relative**, not bundle-relative. That is an Obsidian
+convention, not a choice this harness makes — so if you copy or rename the bundle, the paths need
+rewriting:
+
+```bash
+sed -i 's|"starter-bundle/|"your-vault-folder/|g' your-vault-folder/maps/*.canvas
+```
+
+The validator checks every `file` node, so a missed rewrite is an error rather than a silently
+blank card.
+
+---
+
+## Bases
+
+Bases (Obsidian **1.9+**) are live table views over frontmatter. They are the payoff for the
+frontmatter contract: structured metadata becomes queryable.
+
+Four ship in the starter bundle:
+
+| Base | What it answers |
+| --- | --- |
+| `stale-concepts.base` | **The maintenance queue.** Which concepts have gone longest without verification. |
+| `coverage.base` | What is mapped, grouped by type — and which concepts have no verification SHA at all. |
+| `by-domain.base` | What belongs to each business domain. |
+| `ticket-index.base` | Which concepts a given ticket touched. |
+
+`stale-concepts.base` is the one to pin. Its "Staleness Radar" view sorts by `timestamp` ascending
+with `verified_against` alongside, turning the discipline into a worklist. Without it, the
+frontmatter contract is bookkeeping nobody reads.
+
+If you are on an older Obsidian, delete the `bases/` directory — nothing else depends on it.
+
+---
+
+## Core Plugins Only
+
+`templates/obsidian/core-plugins.json` enables graph, backlinks, outgoing links, canvas, Bases,
+tag pane, properties, bookmarks, and outline. **No community plugins are required.**
+
+That is deliberate. A vault that needs third-party plugins to be readable is a vault that breaks
+for the next person.
+
+---
+
+## Bookmarks
+
+Worth curating: `start-here.md`, the root `index.md`, your main canvas, the staleness Base — and
+at least one **source-of-truth document from outside the bundle**, as a standing reminder that the
+vault is the map and not the thing itself.
+
+---
+
+## Housekeeping
+
+Commit the shared config; ignore the per-user state:
+
+```gitignore
+# Obsidian per-user state (the vault config itself is committed)
+**/.obsidian/workspace.json
+**/.obsidian/workspace-mobile.json
+```
+
+And do not leave a stray `.obsidian/` inside the bundle from opening it directly once. An empty
+`app.json` there means Obsidian falls back to wikilinks, which fail validation — a trap that is
+hard to diagnose because everything looks configured.
+
+---
+
+## Related Reading
+
+- [Knowledge Vault Guide](GUIDE.md) — the method
+- [Adoption Playbook](ADOPTION-PLAYBOOK.md) — running your first build
+- [JSONCanvas spec](https://jsoncanvas.org)
+- [Obsidian Bases documentation](https://help.obsidian.md/bases)

--- a/knowledge-vault/docs/SAW-VAULT-BUILD.md
+++ b/knowledge-vault/docs/SAW-VAULT-BUILD.md
@@ -61,7 +61,7 @@ starting; if a number has moved, use the new one.
 | Skills (`.claude/skills/*/SKILL.md`) | `skill` | 20 | `skills-a`, `skills-b` |
 | Portable skill mirrors (`.agents/skills/*/SKILL.md`) | folded into `skill` | 20 | `skills-a`, `skills-b` |
 | Claude slash commands (`.claude/commands/*.md`, excl. README) | `command` | 24 | `commands-a`, `commands-b` |
-| Gemini media commands (no Claude counterpart) | `command` | 10 | `commands-c` |
+| Gemini media commands (no Claude counterpart) | `command` | 11 | `commands-c` |
 | Cursor rules (`.cursor/rules/*.mdc`), grouped into families | `guide` | 4 | `providers` |
 | Claude hooks (`.claude/hooks/*.sh`) | `script` | 3 | `providers` |
 | Augment rules (`agent_providers/augment/rules/*.md`) | `guide` | 6 | `providers` |
@@ -72,7 +72,7 @@ Notes on folding:
   other providers' formats. One `agent-role` concept per role, carrying all three paths in
   `sources`. Do not write thirty-three role concepts.
 - Same for skills: `.claude/skills/<n>/SKILL.md` and `.agents/skills/<n>/SKILL.md` are one skill.
-- Gemini has 30 TOML commands. Twenty mirror Claude commands (fold them in); ten under
+- Gemini has 30 TOML commands. Nineteen mirror Claude commands (fold them in); eleven under
   `.gemini/commands/media/` have no Claude counterpart and get their own concepts.
 - Eighteen cursor rules grouped into four `guide` concepts by prefix family:
   core (`00`–`02`), methodology (`03`–`04`), stack (`10`–`16`), agent and background (`20`–`31`).

--- a/knowledge-vault/docs/SAW-VAULT-BUILD.md
+++ b/knowledge-vault/docs/SAW-VAULT-BUILD.md
@@ -1,0 +1,916 @@
+# SAW Vault Build
+
+**Purpose**: The runnable, pre-scoped prompt for building this repository's own knowledge vault.
+
+**Audience**: Maintainers of this repo. Not a template — every path, count, and batch below was
+enumerated against this working tree and is meant to be executed as written.
+
+**Method**: [GUIDE.md](GUIDE.md) explains *why* each rule exists. [BUILD-PROMPT.md](BUILD-PROMPT.md)
+is the stack-neutral version. This document does not repeat either; it supplies the parameters they
+leave blank.
+
+**Enumerated against**: commit `f03e213`, branch `SAW-45-okf-knowledge-vault-subsystem`.
+
+---
+
+## Why This Repo Is The Ideal Dogfood
+
+This harness is not a web application. It has no HTTP routes, no ORM, no database tables, no
+payment provider. That is exactly what makes it the right first external build.
+
+The starter config ships twelve **stack-agnostic** types — `domain`, `architecture`, `integration`,
+`environment`, `runbook`, `process`, `pattern`, `adr`, `sop`, `agent-role`, `skill`, `guide` — and
+deliberately omits the web-app-shaped types (`api-endpoint`, `database-table`, `page-route`) that
+the reference build needed. The claim embedded in that decision is that the twelve are genuinely
+portable and the omitted ones were correctly identified as local.
+
+Building this vault tests that claim under adversarial conditions:
+
+- If the twelve types cover this repo's artifacts with only a handful of additions, the
+  genericization holds.
+- If concepts here come out shaped like they are describing something they are not, the starter
+  config over-fitted to its source and the fix is upstream, not local.
+
+Two specific stresses worth naming before starting:
+
+1. **`adr` has no source.** There is no `docs/adr/` directory in this repo. The type is
+   `resource_required: true` and `stub: true`, so it cannot be used without inventing a source.
+   Either the harness grows an ADR practice or the type sits unused here. Do not fabricate ADRs to
+   fill the slot.
+2. **`pattern` describes shipped templates, not live code.** The eighteen files under
+   `patterns_library/` are reference implementations the harness distributes; they are not called by
+   anything in this repo. The "code wins over docs" rule has to be read carefully — the exemplar
+   *is* the artifact.
+
+---
+
+## Scope: What Gets Mapped
+
+All counts below were produced by running the enumeration commands in
+[Appendix A](#appendix-a--enumeration-commands) against the working tree. Re-run them before
+starting; if a number has moved, use the new one.
+
+### Provider surfaces and agent configuration
+
+| Artifact class | Concept type | Count | Batch lane |
+| --- | --- | --- | --- |
+| Provider surfaces (`.claude`, `.gemini`, `.codex`, `.cursor`, `.agents`) | `provider` | 5 | `providers` |
+| Agent role definitions (`.claude/agents/*.md`, excl. README) | `agent-role` | 11 | `roles` |
+| Codex role mirrors (`.codex/agents/*.toml`) | folded into `agent-role` | 11 | `roles` |
+| Augment role prompts (`agent_providers/claude_code/prompts/*.md`) | folded into `agent-role` | 11 | `roles` |
+| Skills (`.claude/skills/*/SKILL.md`) | `skill` | 20 | `skills-a`, `skills-b` |
+| Portable skill mirrors (`.agents/skills/*/SKILL.md`) | folded into `skill` | 20 | `skills-a`, `skills-b` |
+| Claude slash commands (`.claude/commands/*.md`, excl. README) | `command` | 24 | `commands-a`, `commands-b` |
+| Gemini media commands (no Claude counterpart) | `command` | 10 | `commands-c` |
+| Cursor rules (`.cursor/rules/*.mdc`), grouped into families | `guide` | 4 | `providers` |
+| Claude hooks (`.claude/hooks/*.sh`) | `script` | 3 | `providers` |
+| Augment rules (`agent_providers/augment/rules/*.md`) | `guide` | 6 | `providers` |
+
+Notes on folding:
+
+- The eleven Codex TOML agents and eleven Augment prompt files are **the same eleven roles** in
+  other providers' formats. One `agent-role` concept per role, carrying all three paths in
+  `sources`. Do not write thirty-three role concepts.
+- Same for skills: `.claude/skills/<n>/SKILL.md` and `.agents/skills/<n>/SKILL.md` are one skill.
+- Gemini has 30 TOML commands. Twenty mirror Claude commands (fold them in); ten under
+  `.gemini/commands/media/` have no Claude counterpart and get their own concepts.
+- Eighteen cursor rules grouped into four `guide` concepts by prefix family:
+  core (`00`–`02`), methodology (`03`–`04`), stack (`10`–`16`), agent and background (`20`–`31`).
+  Eighteen separate concepts for files this small would be granularity without navigational value.
+
+### The sync engine
+
+| Artifact class | Concept type | Count | Batch lane |
+| --- | --- | --- | --- |
+| `scripts/sync-claude-harness.sh` | `architecture` | 1 | `sync` |
+| `.harness-manifest.schema.json` + `.harness-manifest.yml` | `architecture` | 1 | `sync` |
+| `sync_scope` semantics (multi-domain resolution) | `process` | 1 | `sync` |
+| Shell test suites (`tests/test-*.sh`) | `test-suite` | 9 | `sync` |
+| Sync fixtures (`tests/fixtures/sync/*`) + `examples/manifests/*` | `guide` | 1 | `sync` |
+| Remaining `scripts/*` (10 files) | `script` | 10 | `operations` |
+
+`scripts/` holds 11 files total; `sync-claude-harness.sh` is pulled out as `architecture` above, so
+the remaining 10 become `script` concepts.
+
+### Subsystems
+
+| Artifact class | Concept type | Count | Batch lane |
+| --- | --- | --- | --- |
+| Dark factory (overview of the subsystem) | `architecture` | 1 | `subsystems` |
+| Dark factory operator scripts (`dark-factory/scripts/*.sh`) | `runbook` | 5 | `subsystems` |
+| Dark factory team layouts (`templates/team-layouts/*.sh`) | `runbook` | 3 | `subsystems` |
+| Dark factory guides (`dark-factory/docs/*.md`) | `guide` | 4 | `subsystems` |
+| Dark factory tmux / env topology | `environment` | 1 | `subsystems` |
+| Pattern library (overview) | `architecture` | 1 | `patterns` |
+| Patterns (`patterns_library/*/*.md`, excl. README) | `pattern` | 18 | `patterns` |
+| Spec templates (`specs_templates/*.md`) | `guide` | 5 | `subsystems` |
+| Lint configs (`linting_configs/`) | `guide` | 1 | `subsystems` |
+| Provider assets (`agent_providers/`, overview) | `architecture` | 1 | `providers` |
+| Project workflow scaffold (`project_workflow/`) | `guide` | 1 | `operations` |
+| Knowledge vault subsystem (this one) | `architecture` | 1 | `subsystems` |
+
+### Process and methodology knowledge
+
+These have no single file to point at; they are the institutional knowledge the repo encodes.
+Each cites the documents that carry it.
+
+| Concept | Concept type | Count | Batch lane |
+| --- | --- | --- | --- |
+| Three-Layer Architecture (hooks / commands / skills) | `architecture` | 1 | `methodology` |
+| vNext Workflow Contract (v1.4) | `process` | 1 | `methodology` |
+| Exit states and chain of custody | `process` | 1 | `methodology` |
+| Stop-the-Line gate (AC/DoD) | `process` | 1 | `methodology` |
+| Role collapsing authority | `process` | 1 | `methodology` |
+| Three-stage PR review | `process` | 1 | `methodology` |
+| Round Table philosophy | `guide` | 1 | `methodology` |
+| Evidence-based delivery | `guide` | 1 | `methodology` |
+| Pattern discovery protocol | `process` | 1 | `methodology` |
+| SAFe x AI-DLC methodology layer | `process` | 1 | `methodology` |
+| Domain adaptation (non-SWE teams) | `guide` | 1 | `methodology` |
+| Harness sync and fork workflow | `process` | 1 | `sync` |
+
+### Operations
+
+| Artifact class | Concept type | Count | Batch lane |
+| --- | --- | --- | --- |
+| GitHub workflows (`.github/workflows/*.yml`) | `integration` | 4 | `operations` |
+| Release process (`scripts/generate-changelog.sh`, `HARNESS_CHANGELOG.yml`) | `process` | 1 | `operations` |
+| Pre-release checklist (`docs/release/PRE-RELEASE-CHECKLIST.md`) | `sop` | 1 | `operations` |
+| Version upgrade notes (`docs/releases/*.md`) | `guide` | 1 | `operations` |
+
+### Source-of-truth document stubs
+
+The repo holds 68 files under `docs/`. Not all warrant a concept: `docs/archive/` (5 files),
+`docs/agent-outputs/qa-validations/` (9 files), and the four `REORGANIZATION-*` reports are
+historical records, not live knowledge. Skip them and say so in the log.
+
+| Directory | Files | Concept type | Count | Batch lane |
+| --- | --- | --- | --- | --- |
+| `docs/guides/` | 8 | `guide` | 8 | `docs-a` |
+| `docs/sop/` | 3 | `sop` | 3 | `docs-a` |
+| `docs/onboarding/` | 6 | `guide` | 6 | `docs-a` |
+| `docs/workflow/` | 6 | `process` | 6 | `docs-b` |
+| `docs/whitepapers/` | 6 | `guide` | 6 | `docs-b` |
+| `docs/database/` | 4 | `guide` | 4 | `docs-b` |
+| `docs/security/` | 2 | `guide` | 2 | `docs-b` |
+| `docs/ci-cd/` | 2 | `guide` | 2 | `operations` |
+| `docs/team/`, `docs/templates/`, `docs/patterns/` | 3 | `guide` | 3 | `docs-b` |
+| `docs/HARNESS_SYNC_GUIDE.md`, `docs/HARNESS_MANIFEST_SCHEMA.md` | 2 | `guide` | 2 | `sync` |
+| Root docs (`README`, `AGENTS`, `CONTRIBUTING`, `CLAUDE`, `TEMPLATE_SETUP`, `SECURITY`) | 6 | `guide` | 6 | `docs-a` |
+
+### Domains and navigation
+
+| Item | Concept type | Count | Batch lane |
+| --- | --- | --- | --- |
+| Domain concepts (see config below) | `domain` | 5 | `navigation` |
+| `index.md` cascade (root + one per section directory) | reserved | ~12 | `navigation` |
+| `start-here.md` | `guide` | 1 | `navigation` |
+| `log.md` | reserved | 1 | `navigation` |
+| Canvases (`maps/*.canvas`) | reserved | 2 | `navigation` |
+| Bases (`bases/*.base`) | reserved | 4 | `navigation` |
+
+**Estimated concept total: roughly 200.** This is an estimate derived from the counts above, not a
+target. Do not pad toward it and do not merge concepts to stay under it.
+
+---
+
+## The SAW `vault-config.json`
+
+Drop this at `docs/knowledge-vault/_meta/vault-config.json`. It is the starter config with
+`bundle_root`, `obsidian_vault_root`, `domains`, `tags`, and four added types changed.
+
+```json
+{
+  "okf_version": "0.1",
+  "bundle_root": "docs/knowledge-vault",
+  "obsidian_vault_root": ".",
+
+  "domains": ["methodology", "providers", "sync", "subsystems", "operations"],
+
+  "statuses": ["active", "deprecated", "experimental", "planned"],
+
+  "max_concept_lines": 60,
+
+  "frontmatter": {
+    "required": ["type", "title", "description", "tags", "timestamp", "status"],
+    "optional": [
+      "resource",
+      "domain",
+      "ticket",
+      "sources",
+      "docs",
+      "verified_against",
+      "okf_version"
+    ],
+    "max_description_length": 160,
+    "path_fields": ["resource", "sources", "docs"]
+  },
+
+  "link_rules": {
+    "style": "relative-markdown",
+    "concept_links_stay_in_bundle": true,
+    "external_repo_links_only_under": "Citations",
+    "forbidden": ["wikilinks", "leading-slash-paths", "github-urls-for-repo-files"]
+  },
+
+  "tags": [
+    "methodology",
+    "providers",
+    "sync",
+    "subsystems",
+    "operations",
+
+    "agents",
+    "skills",
+    "commands",
+    "hooks",
+    "workflow",
+    "gates",
+    "process",
+    "patterns",
+    "testing",
+    "ci",
+    "release",
+    "onboarding",
+    "security",
+    "orchestration",
+    "ssot-stub",
+    "okf"
+  ],
+
+  "types": {
+    "domain": {
+      "sections": ["Overview", "Members", "Key Flows", "Citations"],
+      "resource_required": false
+    },
+    "architecture": {
+      "sections": ["Overview", "Design", "Related Concepts", "Citations"],
+      "resource_required": false
+    },
+    "integration": {
+      "sections": [
+        "Overview",
+        "Touchpoints",
+        "Configuration",
+        "Failure Modes & Health",
+        "Citations"
+      ],
+      "resource_required": false
+    },
+    "environment": {
+      "sections": ["Overview", "Topology", "Access & Deployment", "Citations"],
+      "resource_required": false
+    },
+    "runbook": {
+      "sections": ["Overview", "When To Use", "Procedure Map", "Citations"],
+      "resource_required": false
+    },
+    "process": {
+      "sections": ["Overview", "Flow", "Roles Involved", "Citations"],
+      "resource_required": false
+    },
+    "pattern": {
+      "sections": ["Overview", "Exemplars", "Citations"],
+      "resource_required": true,
+      "stub": true
+    },
+    "adr": {
+      "sections": ["Overview", "Decision", "Affected Concepts", "Citations"],
+      "resource_required": true,
+      "stub": true
+    },
+    "sop": {
+      "sections": ["Overview", "When It Applies", "Affected Concepts", "Citations"],
+      "resource_required": true,
+      "stub": true
+    },
+    "agent-role": {
+      "sections": [
+        "Overview",
+        "Responsibilities",
+        "Skills & SOPs",
+        "Handoffs",
+        "Citations"
+      ],
+      "resource_required": true,
+      "stub": true
+    },
+    "skill": {
+      "sections": ["Overview", "Routes To", "Used By Roles", "Citations"],
+      "resource_required": true,
+      "stub": true
+    },
+    "provider": {
+      "sections": [
+        "Overview",
+        "Surface Layout",
+        "Capabilities Exposed",
+        "Sync & Parity",
+        "Citations"
+      ],
+      "resource_required": true
+    },
+    "command": {
+      "sections": [
+        "Overview",
+        "Invocation",
+        "What It Does",
+        "Provider Parity",
+        "Citations"
+      ],
+      "resource_required": true,
+      "stub": true
+    },
+    "script": {
+      "sections": ["Overview", "Inputs & Outputs", "Invoked By", "Citations"],
+      "resource_required": true,
+      "stub": true
+    },
+    "test-suite": {
+      "sections": ["Overview", "What It Proves", "Fixtures", "Citations"],
+      "resource_required": true,
+      "stub": true
+    },
+    "guide": {
+      "sections": [],
+      "resource_required": false
+    },
+    "meta": {
+      "sections": [],
+      "resource_required": false,
+      "internal": true
+    },
+    "template": {
+      "sections": [],
+      "resource_required": false,
+      "internal": true
+    }
+  }
+}
+```
+
+### Why these four additions
+
+- **`provider`** — a provider surface is a whole configuration dialect, not an integration with a
+  third party. It needs a **Sync & Parity** section, because parity across the five surfaces is the
+  thing that actually breaks.
+- **`command`** — a slash command has a fixed shape: invocation, effect, whether the other providers
+  carry it. `runbook` has nowhere to record parity; `skill` implies model invocation rather than
+  user invocation.
+- **`script`** — shell entry points need **Inputs & Outputs** and **Invoked By**. `runbook`
+  describes a human procedure; a script is an artifact with a call graph.
+- **`test-suite`** — **What It Proves** is the load-bearing section, and no shipped type has it.
+  Without it, a test concept degrades into a restatement of the file listing.
+
+All four end in `Citations`, all four have fixed ordered sections, and the three stub types require
+an out-of-bundle citation — matching the constitution in
+[CONVENTIONS.md](../templates/starter-bundle/_meta/CONVENTIONS.md).
+
+### Two deviations from the default, deliberate
+
+- **`obsidian_vault_root` is `"."` (repo root), not the bundle's parent `docs`.** The playbook's
+  rule of thumb is "the parent of the bundle", which works when sources live under `docs/`. Here
+  they do not: concepts cite `.claude/`, `.cursor/`, `tests/`, `scripts/`, `patterns_library/`. Only
+  a repo-root Obsidian vault keeps those citations clickable. The field is advisory — the validator
+  does not read it — so this costs nothing but must be a conscious choice.
+- **Templates and matching skeletons for the four added types must be written** under
+  `docs/knowledge-vault/_meta/templates/`, carrying per-section length budgets, before generation
+  starts. A type in the config with no template produces structurally-correct emptiness.
+
+---
+
+## Directory Taxonomy
+
+Three orthogonal axes, per [GUIDE.md](GUIDE.md). Structural mirrors the repo, semantic re-groups by
+intent, conceptual holds what has no file.
+
+```text
+docs/knowledge-vault/
+├── _meta/                      # config, manifest, templates (not concepts)
+├── index.md                    # root of the cascade
+├── start-here.md               # the learning door
+├── log.md
+│
+├── providers/                  # STRUCTURAL — the five surfaces
+│   ├── index.md
+│   ├── claude-code.md          # provider
+│   ├── gemini-cli.md
+│   ├── codex.md
+│   ├── cursor.md
+│   ├── agents-portable.md
+│   ├── rules/                  # cursor rule families (guide)
+│   └── hooks/                  # .claude/hooks/*.sh (script)
+│
+├── roles/                      # STRUCTURAL — 11 agent-role concepts
+├── skills/                     # STRUCTURAL — 20 skill concepts
+├── commands/                   # STRUCTURAL — 34 command concepts
+│
+├── sync/                       # STRUCTURAL — the sync engine
+│   ├── index.md
+│   ├── harness-sync-engine.md  # architecture
+│   ├── manifest-schema.md      # architecture
+│   ├── sync-scope.md           # process
+│   └── tests/                  # 9 test-suite concepts
+│
+├── subsystems/                 # STRUCTURAL — the shipped subsystems
+│   ├── index.md
+│   ├── dark-factory/
+│   ├── pattern-library/
+│   ├── spec-templates/
+│   ├── linting/
+│   └── knowledge-vault/
+│
+├── patterns/                   # STRUCTURAL — 18 pattern stubs
+│
+├── operations/                 # STRUCTURAL — CI, release, scripts
+│   ├── index.md
+│   ├── workflows/              # 4 integration concepts
+│   ├── scripts/                # 10 script concepts
+│   └── release/
+│
+├── domains/                    # SEMANTIC — the five curated cross-cuts
+│   ├── methodology.md
+│   ├── providers.md
+│   ├── sync.md
+│   ├── subsystems.md
+│   └── operations.md
+│
+├── methodology/                # CONCEPTUAL — knowledge with no single file
+│   ├── index.md
+│   ├── three-layer-architecture.md
+│   ├── vnext-workflow-contract.md
+│   ├── exit-states.md
+│   ├── stop-the-line-gate.md
+│   ├── role-collapsing.md
+│   ├── three-stage-pr-review.md
+│   ├── round-table-philosophy.md
+│   ├── evidence-based-delivery.md
+│   ├── pattern-discovery-protocol.md
+│   ├── safe-ai-dlc.md
+│   └── domain-adaptation.md
+│
+├── knowledge/                  # CONCEPTUAL — SSoT doc stubs
+│   ├── index.md
+│   ├── guides/  onboarding/  workflow/  whitepapers/
+│   ├── database/  security/  ci-cd/
+│   └── root-docs/
+│
+├── maps/                       # canvases
+└── bases/                      # Obsidian Bases views
+```
+
+The `domains/` axis is the one that earns its keep. `providers/claude-code.md` is where a file
+lives; `domains/providers.md` is where someone asks "how does multi-provider parity actually work"
+and gets routed across `sync/`, `providers/`, and `operations/` in one place.
+
+---
+
+## The `vault-sync` Watch List
+
+These globs go into the sync skill's drift check. A concept is stale if and only if a path changed
+by `git diff --name-only $BASELINE..HEAD` matches its `resource` or one of its `sources`.
+
+```text
+.claude/agents/*.md
+.claude/skills/*/SKILL.md
+.claude/commands/*.md
+.claude/hooks/*.sh
+.claude/settings.template.json
+.claude/hooks-config.json
+.claude/team-config.json
+.agents/skills/*/SKILL.md
+.gemini/commands/**/*.toml
+.codex/agents/*.toml
+.codex/config.toml
+.cursor/rules/*.mdc
+agent_providers/**/*.md
+agent_providers/**/*.sh
+scripts/*.sh
+scripts/*.py
+tests/test-*.sh
+tests/fixtures/**
+.harness-manifest.yml
+.harness-manifest.schema.json
+HARNESS_CHANGELOG.yml
+.github/workflows/*.yml
+dark-factory/**/*.sh
+dark-factory/**/*.md
+patterns_library/**/*.md
+specs_templates/*.md
+linting_configs/*
+project_workflow/**
+examples/manifests/*.yml
+knowledge-vault/scripts/*.mjs
+knowledge-vault/templates/**
+docs/**/*.md
+README.md
+AGENTS.md
+CONTRIBUTING.md
+CLAUDE.md
+TEMPLATE_SETUP.md
+```
+
+Two exclusions, both intentional:
+
+- `docs/archive/**` and `docs/agent-outputs/**` are historical; changes there do not invalidate
+  anything. They are not in the watch list because no concept cites them.
+- `docs/knowledge-vault/**` is the vault itself. Including it would make every vault edit mark the
+  whole vault stale.
+
+---
+
+## Agent Fan-Out Plan
+
+Sized to the inventory above. Phase boundaries are hard: no generation agent starts before the
+manifest holds every ID, because the manifest is the link allowlist.
+
+### Phase 1 — Extract (8 agents)
+
+Each writes a fact digest into the `notes` field of its concepts' manifest entries. No prose, no
+concept files.
+
+- **E1** reads `.claude/agents/*.md`, `.codex/agents/*.toml`,
+  `agent_providers/claude_code/prompts/*.md` — produces notes for 11 roles.
+- **E2** reads `.claude/skills/*/SKILL.md`, `.agents/skills/*/SKILL.md` — 20 skills.
+- **E3** reads `.claude/commands/*.md`, `.gemini/commands/**/*.toml` — 34 commands.
+- **E4** reads `.cursor/rules/*.mdc`, `.claude/hooks/*.sh`, `agent_providers/augment/**` —
+  5 providers, 4 rule families, 3 hooks, 6 augment rules.
+- **E5** reads `scripts/*`, `.harness-manifest*`, `tests/test-*.sh`, `tests/fixtures/**`,
+  `examples/manifests/*` — the sync engine, 9 test suites, 10 scripts.
+- **E6** reads `dark-factory/**`, `patterns_library/**`, `specs_templates/*`, `linting_configs/*`,
+  `knowledge-vault/**` — the subsystems and 18 patterns.
+- **E7** reads `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `CLAUDE.md`, `docs/guides/*`,
+  `docs/workflow/*`, `docs/sop/*` — 12 methodology concepts.
+- **E8** reads `.github/workflows/*.yml`, `docs/ci-cd/*`, `docs/release*/**`,
+  `HARNESS_CHANGELOG.yml`, `project_workflow/**` — operations.
+
+**Gate**: the manifest lists every concept ID with `type`, `title`, `path`, `description`, `tags`,
+`batch`, and `notes`, before Phase 2 begins.
+
+### Phase 2 — Generate (24 agents)
+
+One agent per batch lane, each carrying the four-part prompt.
+
+| Lane | Agents | Concepts |
+| --- | --- | --- |
+| `roles` | 2 | 11 agent-role |
+| `skills-a`, `skills-b` | 2 | 20 skill |
+| `commands-a`, `commands-b`, `commands-c` | 3 | 34 command |
+| `providers` | 2 | 5 provider, 4 rule families, 3 hooks, 6 augment rules, 1 architecture |
+| `sync` | 3 | 2 architecture, 1 process, 9 test-suite, 2 guide, 1 process |
+| `subsystems` | 3 | dark factory (14), spec templates (5), linting (1), vault (1) |
+| `patterns` | 2 | 18 pattern, 1 architecture |
+| `methodology` | 3 | 12 concepts |
+| `operations` | 2 | 4 integration, 10 script, 3 release |
+| `docs-a`, `docs-b` | 2 | ~40 SSoT stubs |
+
+**Gate**: `--allow-broken-links` validation passes before Phase 3.
+
+### Phase 3 — Navigate (5 agents)
+
+| Agent | Produces |
+| --- | --- |
+| N1 | Root `index.md` plus section indexes for `providers/`, `roles/`, `skills/`, `commands/` |
+| N2 | Section indexes for `sync/`, `subsystems/`, `patterns/`, `operations/`, `methodology/`, `knowledge/` |
+| N3 | The 5 `domain` concepts under `domains/` |
+| N4 | `start-here.md` — every step states why it comes there |
+| N5 | `maps/*.canvas` and `bases/*.base` |
+
+The vertical slice for `start-here.md`: a ticket enters at `/start-work`, the BSA role writes AC,
+the Stop-the-Line gate admits it, an implementer exits at "Ready for QAS", QAS gates, RTE opens the
+PR, and `.github/workflows/pr-validation.yml` runs. Trace that end to end with real paths.
+
+### Phase 4 — Verify (12 adversarial agents)
+
+Verifiers do not fix; they file findings with file-and-line evidence. Assign one verifier per
+Phase 2 lane group, plus two cross-cutting:
+
+| Verifier | Target |
+| --- | --- |
+| V1–V9 | One per generation lane group — re-derive every claim from source |
+| V10 | Link legality: no wikilinks, no leading slashes, no repo-host URLs, every link in the manifest |
+| V11 | Count integrity: every number stated in a concept re-counted from disk |
+| V12 | Stub discipline: does any stub restate more than a paragraph of its source? |
+
+V11 exists specifically because this repo's concepts will state counts ("20 skills", "5 provider
+surfaces") and a wrong count is the most embarrassing possible failure in a document about
+verifiability. On the reference build, 14 adversarial verifiers produced 25 evidence-backed
+findings; all were corrected before merge. Budget for the same and do not treat zero findings as
+success — treat it as a sign the verifiers were too gentle.
+
+---
+
+## Runnable Prompt Blocks
+
+Paste these as-is. Replace nothing except the per-agent scope line.
+
+### Phase 1 — extraction agent
+
+```text
+You are an extraction agent for this repository's knowledge vault build.
+
+SCOPE: <paste the "Reads" cell for your agent from the Phase 1 table>
+
+Read every file in scope. For each concept assigned to you in
+docs/knowledge-vault/_meta/manifest.json, write a fact digest into that entry's "notes" field.
+
+A fact digest is pipe-separated, dense, and factual. No prose, no adjectives, no
+recommendations. Example shape:
+  "invoked by /start-work | reads .harness-manifest.yml | writes patch to /tmp | 3 exit codes"
+
+Rules:
+- Facts must be true of the file as it exists at HEAD. If a doc contradicts a script, the
+  script wins; record the discrepancy in the digest.
+- Record the exact repo-root-relative paths. They become "resource" and "sources".
+- Count things by listing them, never by estimating.
+- Do NOT write concept .md files. Do NOT invent concepts not in the manifest.
+- If you find an artifact with no manifest entry, report it as a suggestion at the end.
+
+Output: the updated manifest entries, plus a list of suggested missing concepts.
+```
+
+### Phase 2 — generation agent
+
+```text
+You are a generation agent for this repository's knowledge vault build.
+Your lane: <lane name>. Your concepts: <list of manifest IDs>.
+
+You are given four things and must use all four.
+
+1. TYPE TEMPLATE
+   docs/knowledge-vault/_meta/templates/<type>.md — the frontmatter stencil and the fixed,
+   ordered H2 list with per-section length budgets. Do not add, remove, or reorder H2s.
+
+2. GOLDEN EXAMPLE
+   <path to one already-accepted concept of the same type>
+   Match its density, its voice, and its level of abstraction.
+
+3. THE HARD RULES (the constitution — knowledge-vault/templates/starter-bundle/_meta/CONVENTIONS.md)
+   - One concept per file, kebab-case filename, exactly one H1, all sections H2, ends in
+     "## Citations".
+   - Required frontmatter: type, title, description (one sentence, <=160 chars), tags (from the
+     controlled vocabulary in vault-config.json), timestamp, status.
+   - timestamp is the date you verified the claims against source. verified_against is the short
+     git SHA you verified at. Set both honestly.
+   - Summarize, never duplicate. If you are restating more than a paragraph, stop and link.
+   - Facts must be true of the artifact as it exists. Name what the code actually does, not what
+     it should do. Where code and docs disagree, the code wins and you note the discrepancy.
+   - Relative markdown links only. Never wikilinks, never leading-slash paths, never
+     repository-host URLs for files in this repo. Code files are named as inline code, never
+     linked; they belong in resource/sources.
+   - Links leaving the bundle appear only under "## Citations".
+   - No emoji. Max 60 lines per concept. Tables need leading and trailing pipes. Fenced blocks
+     declare a language.
+   - Environment variable names may be mentioned; values never.
+
+4. THE ID REGISTRY (the link allowlist)
+   docs/knowledge-vault/_meta/manifest.json
+   Link ONLY to concept IDs listed there. If a concept you want does not exist, name it in prose
+   without a link and report it as a suggestion. NEVER invent links.
+
+Your manifest entries carry a "notes" fact digest from the extraction phase. Use it, but open the
+actual source file before asserting anything you did not find in the digest.
+
+Output: one .md file per assigned concept at its manifest "path", plus a list of suggested
+missing concepts and any code/doc discrepancies you found.
+```
+
+### Phase 3 — navigation agent
+
+```text
+You are a navigation agent for this repository's knowledge vault build.
+Your assignment: <N1..N5 row from the Phase 3 table>
+
+index.md files carry no frontmatter and are not concepts (the root index.md is the sole
+exception: it carries okf_version plus the standard fields). They are curated and annotated —
+each link gets a clause saying what the reader will find, not just the title.
+
+start-here.md is the learning door, not a table of contents. Every step must state WHY it comes
+at that point in the order. It ends in one traced vertical slice through this repo, using real
+paths: a ticket enters at /start-work, BSA writes AC, the Stop-the-Line gate admits it, an
+implementer exits at "Ready for QAS", QAS gates, RTE opens the PR,
+.github/workflows/pr-validation.yml runs.
+
+Link ONLY to concept IDs in docs/knowledge-vault/_meta/manifest.json. Never invent links.
+Canvas nodes must reference files that exist on disk.
+```
+
+### Phase 4 — verifier agent
+
+```text
+You are an adversarial verifier for this repository's knowledge vault build.
+Your target: <verifier row from the Phase 4 table>
+
+Your job is to BREAK claims, not to improve prose. You do not edit concepts.
+
+For every factual assertion in your target concepts:
+- Open the source file named in resource/sources and confirm the claim against it.
+- Re-count every number stated. Run the count; do not eyeball it.
+- Check that every link resolves and that its target ID is in the manifest.
+- Check that stub-type concepts cite an out-of-bundle source and do not restate it.
+- Check that timestamp and verified_against are plausible: a concept claiming verification at a
+  SHA whose source has since changed is a finding.
+
+File each finding as: concept ID | claim | evidence (file:line) | severity (wrong | minor).
+"Wrong" means a reader acting on it would do the wrong thing. "Minor" means imprecise but not
+misleading.
+
+Report zero findings only if you genuinely found none after checking every assertion. State how
+many assertions you checked.
+```
+
+---
+
+## The Gate
+
+The build is not done until both commands exit 0.
+
+```bash
+node knowledge-vault/scripts/validate-vault.mjs --vault docs/knowledge-vault
+npx markdownlint-cli2 "docs/knowledge-vault/**/*.md"
+```
+
+The `--vault` flag is mandatory here, not optional: this repo will contain two bundles once the
+build lands — `knowledge-vault/templates/starter-bundle` and `docs/knowledge-vault` — and the
+validator refuses to guess when it finds more than one.
+
+Use `--allow-broken-links` during Phase 2 only. Never in CI.
+
+Wire it in: `knowledge-vault/templates/github/validate-vault.yml` is the opt-in workflow template.
+Copy it to `.github/workflows/`, bringing the repo from 4 workflows to 5. In the reference project
+the validator existed, passed locally, and ran in no workflow, so drift was invisible to CI until an
+audit caught it. That gap is avoidable here and should be closed in the same change that adds the
+vault.
+
+---
+
+## Linear Epic and Stories
+
+Ticket prefix `SAW`. File these rather than treating the above as a suggestion.
+
+### Epic: Build the SAW knowledge vault
+
+**Description**: Build this repository's own OKF knowledge vault using the shipped
+`knowledge-vault/` subsystem, and use the build as the falsification test for whether the twelve
+stack-agnostic types genericized correctly.
+
+**Business outcome**: A newcomer or agent can orient in this repo from a map that is provably
+current, and any over-fitting left in the starter config is found and fixed upstream.
+
+**Metrics**:
+
+- `validate-vault.mjs --vault docs/knowledge-vault` exits 0 in CI on every PR.
+- Every concept carries `verified_against` set to a real SHA.
+- Adversarial verification findings are recorded and every one is corrected before merge.
+
+---
+
+### Story 1: Author the SAW vault config and type templates
+
+**As a** vault maintainer, **I want** a SAW-specific `vault-config.json` plus templates for the
+added types, **so that** generation agents have an enforceable contract before any concept exists.
+
+**Acceptance criteria**:
+
+- [ ] `docs/knowledge-vault/_meta/vault-config.json` exists, matching the block in this document.
+- [ ] `bundle_root` is `docs/knowledge-vault`; `obsidian_vault_root` is `.`.
+- [ ] Domains are `methodology`, `providers`, `sync`, `subsystems`, `operations`.
+- [ ] Types `provider`, `command`, `script`, `test-suite` are present with ordered sections ending
+      in `Citations`.
+- [ ] `_meta/templates/provider.md`, `command.md`, `script.md`, `test-suite.md` exist, each with
+      per-section length budgets.
+- [ ] `_meta/CONVENTIONS.md` is present and consistent with the config.
+- [ ] The validator runs against the empty bundle and reports only "no concepts" style output, not
+      config errors.
+
+---
+
+### Story 2: Extraction pass — populate the manifest
+
+**As a** vault maintainer, **I want** a manifest holding every concept ID with a fact digest,
+**so that** generation can run in parallel against a fixed link allowlist.
+
+**Acceptance criteria**:
+
+- [ ] `_meta/manifest.json` lists every concept from the scope tables, each with `id`, `type`,
+      `title`, `path`, `description`, `tags`, `batch`, `notes`.
+- [ ] `baseline_sha` is set to a real short SHA of the commit extraction ran against.
+- [ ] Counts in the manifest match a fresh run of the enumeration commands in Appendix A. Any
+      divergence from this document's stated counts is recorded in the story comments.
+- [ ] The eleven agent roles have one entry each, not one per provider format.
+- [ ] Artifacts found with no planned concept are listed as comments on this story.
+
+---
+
+### Story 3: Generation pass — write the concepts
+
+**As a** vault maintainer, **I want** every planned concept written by a lane agent using the
+four-part prompt, **so that** ~200 files read as though one author wrote them.
+
+**Acceptance criteria**:
+
+- [ ] Every manifest ID has a file at its `path`.
+- [ ] Every concept has the required frontmatter, exactly the H2s its type declares, in order,
+      ending in `## Citations`.
+- [ ] Every concept is 60 lines or fewer.
+- [ ] Every concept sets `verified_against` to a real short SHA and `timestamp` to the date of
+      verification.
+- [ ] Stub-type concepts each carry at least one out-of-bundle citation and restate no more than a
+      paragraph of it.
+- [ ] `validate-vault.mjs --vault docs/knowledge-vault --allow-broken-links` exits 0.
+- [ ] Code/doc discrepancies found during generation are filed as comments, not silently resolved
+      in favour of the doc.
+
+---
+
+### Story 4: Navigation pass — build both doors
+
+**As a** newcomer, **I want** a reference door and a learning door, **so that** I can either look
+something up or be taught the system in order.
+
+**Acceptance criteria**:
+
+- [ ] Root `index.md` carries `okf_version` and links every section index.
+- [ ] Each section directory has an `index.md` with an annotated link per concept.
+- [ ] `start-here.md` orders its steps and states why each step comes where it does.
+- [ ] `start-here.md` ends in one traced vertical slice using real repo paths from `/start-work`
+      through `.github/workflows/pr-validation.yml`.
+- [ ] Five `domain` concepts exist under `domains/`, each re-grouping artifacts by intent rather
+      than by directory.
+- [ ] Canvases under `maps/` reference only files that exist.
+- [ ] `log.md` exists with a dated entry for the build.
+
+---
+
+### Story 5: Adversarial verification pass
+
+**As a** reader trusting this vault, **I want** independent agents to have tried to falsify every
+claim, **so that** trusting it is justified rather than habitual.
+
+**Acceptance criteria**:
+
+- [ ] Twelve verifiers run per the Phase 4 assignment table.
+- [ ] Every finding is recorded as `concept ID | claim | evidence (file:line) | severity`.
+- [ ] Every count asserted anywhere in the vault has been independently re-counted from disk.
+- [ ] Every finding is corrected before merge; corrections bump `timestamp` and `verified_against`
+      of the concepts they touch.
+- [ ] Each verifier reports the number of assertions checked, not only the number of findings.
+- [ ] Findings and their resolutions are posted to Linear as the evidence record.
+
+---
+
+### Story 6: Wire vault validation into CI and vault-sync
+
+**As a** maintainer, **I want** drift to be caught by CI rather than by an audit, **so that** the
+vault cannot silently go stale.
+
+**Acceptance criteria**:
+
+- [ ] `knowledge-vault/templates/github/validate-vault.yml` is copied to `.github/workflows/`,
+      taking the repo from 4 workflows to 5.
+- [ ] The workflow runs `validate-vault.mjs --vault docs/knowledge-vault` without
+      `--allow-broken-links` and fails the build on a non-zero exit.
+- [ ] `yarn`-equivalent markdown linting covers `docs/knowledge-vault/**/*.md` and passes.
+- [ ] The `vault-sync` skill's watch list matches the glob list in this document.
+- [ ] A deliberate test change to a watched path is shown to mark exactly the expected concepts
+      stale, and no others.
+
+---
+
+## Appendix A — Enumeration Commands
+
+Run these before starting. Every count in this document came from them. If a number has moved,
+the number in this document is the one that is wrong.
+
+```bash
+ls -d .claude/skills/*/ | wc -l                          # 20 skills
+ls .claude/agents/*.md | wc -l                           # 12 files = 11 roles + README
+ls .claude/commands/*.md | wc -l                         # 25 files = 24 commands + README
+ls .claude/hooks/*.sh | wc -l                            # 3 hooks
+find .agents -name SKILL.md | wc -l                      # 20 portable skill mirrors
+find .gemini -name '*.toml' | wc -l                      # 30 (20 mirrors + 10 media-only)
+ls .cursor/rules/*.mdc | wc -l                           # 18 rules
+ls .codex/agents/*.toml | wc -l                          # 11 role mirrors
+ls agent_providers/claude_code/prompts/*.md | wc -l      # 11 role prompts
+ls agent_providers/augment/rules/*.md | wc -l            # 6 augment rules
+ls .github/workflows/*.yml | wc -l                       # 4 workflows
+ls tests/test-*.sh | wc -l                               # 9 shell test suites
+ls scripts/* | wc -l                                     # 11 scripts
+find patterns_library -name '*.md' | wc -l               # 19 files = 18 patterns + README
+ls dark-factory/scripts/*.sh | wc -l                     # 5 operator scripts
+ls dark-factory/docs/*.md | wc -l                        # 4 guides
+ls dark-factory/templates/team-layouts/*.sh | wc -l      # 3 team layouts
+ls specs_templates/*.md | wc -l                          # 5 templates
+find docs -type f | wc -l                                # 68 doc files
+git rev-parse --short HEAD                               # baseline_sha
+```
+
+---
+
+## Related Reading
+
+- [Knowledge Vault Guide](GUIDE.md) — the method and why each rule exists
+- [Build Prompt](BUILD-PROMPT.md) — the stack-neutral build prompt
+- [Adoption Playbook](ADOPTION-PLAYBOOK.md) — first-build walkthrough
+- [Conventions](../templates/starter-bundle/_meta/CONVENTIONS.md) — the constitution
+- [Starter config](../templates/starter-bundle/_meta/vault-config.json) — the 12 shipped types

--- a/knowledge-vault/docs/SAW-VAULT-BUILD.md
+++ b/knowledge-vault/docs/SAW-VAULT-BUILD.md
@@ -888,7 +888,7 @@ ls .claude/agents/*.md | wc -l                           # 12 files = 11 roles +
 ls .claude/commands/*.md | wc -l                         # 25 files = 24 commands + README
 ls .claude/hooks/*.sh | wc -l                            # 3 hooks
 find .agents -name SKILL.md | wc -l                      # 20 portable skill mirrors
-find .gemini -name '*.toml' | wc -l                      # 30 (20 mirrors + 10 media-only)
+find .gemini -name '*.toml' | wc -l                      # 30 (19 mirrors + 11 media-only)
 ls .cursor/rules/*.mdc | wc -l                           # 18 rules
 ls .codex/agents/*.toml | wc -l                          # 11 role mirrors
 ls agent_providers/claude_code/prompts/*.md | wc -l      # 11 role prompts

--- a/knowledge-vault/docs/SAW-VAULT-BUILD.md
+++ b/knowledge-vault/docs/SAW-VAULT-BUILD.md
@@ -9,7 +9,11 @@ enumerated against this working tree and is meant to be executed as written.
 is the stack-neutral version. This document does not repeat either; it supplies the parameters they
 leave blank.
 
-**Enumerated against**: commit `f03e213`, branch `SAW-45-okf-knowledge-vault-subsystem`.
+**Enumerated against**: the tip of branch `SAW-45-okf-knowledge-vault-subsystem`.
+
+The counts below are a snapshot and the branch tip moves. Before you start, **re-run
+[Appendix A](#appendix-a--enumeration-commands) and stamp the SHA it prints** — that value becomes
+your `baseline_sha`. If a number here disagrees with what Appendix A returns, Appendix A wins.
 
 ---
 
@@ -141,7 +145,7 @@ Each cites the documents that carry it.
 ### Source-of-truth document stubs
 
 The repo holds 68 files under `docs/`. Not all warrant a concept: `docs/archive/` (5 files),
-`docs/agent-outputs/qa-validations/` (9 files), and the four `REORGANIZATION-*` reports are
+`docs/agent-outputs/qa-validations/` (9 files), and the three `REORGANIZATION-*` reports are
 historical records, not live knowledge. Skip them and say so in the log.
 
 | Directory | Files | Concept type | Count | Batch lane |
@@ -151,7 +155,7 @@ historical records, not live knowledge. Skip them and say so in the log.
 | `docs/onboarding/` | 6 | `guide` | 6 | `docs-a` |
 | `docs/workflow/` | 6 | `process` | 6 | `docs-b` |
 | `docs/whitepapers/` | 6 | `guide` | 6 | `docs-b` |
-| `docs/database/` | 4 | `guide` | 4 | `docs-b` |
+| `docs/database/` | 5 | `guide` | 5 | `docs-b` |
 | `docs/security/` | 2 | `guide` | 2 | `docs-b` |
 | `docs/ci-cd/` | 2 | `guide` | 2 | `operations` |
 | `docs/team/`, `docs/templates/`, `docs/patterns/` | 3 | `guide` | 3 | `docs-b` |
@@ -403,7 +407,7 @@ docs/knowledge-vault/
 │
 ├── roles/                      # STRUCTURAL — 11 agent-role concepts
 ├── skills/                     # STRUCTURAL — 20 skill concepts
-├── commands/                   # STRUCTURAL — 34 command concepts
+├── commands/                   # STRUCTURAL — 35 command concepts
 │
 ├── sync/                       # STRUCTURAL — the sync engine
 │   ├── index.md
@@ -532,7 +536,7 @@ concept files.
 - **E1** reads `.claude/agents/*.md`, `.codex/agents/*.toml`,
   `agent_providers/claude_code/prompts/*.md` — produces notes for 11 roles.
 - **E2** reads `.claude/skills/*/SKILL.md`, `.agents/skills/*/SKILL.md` — 20 skills.
-- **E3** reads `.claude/commands/*.md`, `.gemini/commands/**/*.toml` — 34 commands.
+- **E3** reads `.claude/commands/*.md`, `.gemini/commands/**/*.toml` — 35 commands.
 - **E4** reads `.cursor/rules/*.mdc`, `.claude/hooks/*.sh`, `agent_providers/augment/**` —
   5 providers, 4 rule families, 3 hooks, 6 augment rules.
 - **E5** reads `scripts/*`, `.harness-manifest*`, `tests/test-*.sh`, `tests/fixtures/**`,
@@ -555,7 +559,7 @@ One agent per batch lane, each carrying the four-part prompt.
 | --- | --- | --- |
 | `roles` | 2 | 11 agent-role |
 | `skills-a`, `skills-b` | 2 | 20 skill |
-| `commands-a`, `commands-b`, `commands-c` | 3 | 34 command |
+| `commands-a`, `commands-b`, `commands-c` | 3 | 35 command |
 | `providers` | 2 | 5 provider, 4 rule families, 3 hooks, 6 augment rules, 1 architecture |
 | `sync` | 3 | 2 architecture, 1 process, 9 test-suite, 2 guide, 1 process |
 | `subsystems` | 3 | dark factory (14), spec templates (5), linting (1), vault (1) |

--- a/knowledge-vault/scripts/validate-vault.mjs
+++ b/knowledge-vault/scripts/validate-vault.mjs
@@ -1,0 +1,461 @@
+#!/usr/bin/env node
+/**
+ * validate-vault.mjs — structural validator for an OKF knowledge vault.
+ *
+ * Zero dependencies: node: builtins only. No package.json required.
+ *
+ * The vault's `_meta/vault-config.json` is the machine-readable constitution; this script
+ * enforces it. Checks:
+ *   1. Frontmatter — parseable YAML subset, required fields, enum membership, description length
+ *   2. Sections    — H2 set must exactly match the type's template sections
+ *   3. Links       — relative markdown only; no wikilinks; no repo-host URLs for repo files;
+ *                    concept links resolve inside the bundle; out-of-bundle links only under
+ *                    the citations section and must exist on disk
+ *   4. Paths       — resource / sources / docs must exist on disk
+ *   5. Reserved    — index.md has no frontmatter (root excepted), log.md format
+ *   6. Stubs       — types flagged `stub` must actually cite an out-of-bundle source
+ *   7. Canvas      — .canvas file nodes must reference files that exist
+ *   8. Manifest    — _meta/manifest.json entries <-> files on disk (when a manifest exists)
+ *   9. Orphans     — concepts with zero inbound links (warning; --strict-orphans to fail)
+ *
+ * Exit: 0 clean (warnings allowed), 1 on errors.
+ */
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { join, dirname, resolve, relative, sep } from "node:path";
+
+// ---------------------------------------------------------------- args
+const argv = process.argv.slice(2);
+const args = new Set(argv);
+
+if (args.has("--help") || args.has("-h")) {
+  console.log(`
+validate-vault.mjs — structural validator for an OKF knowledge vault
+
+Usage:
+  node validate-vault.mjs [--vault <dir>] [options]
+
+Options:
+  --vault <dir>          Path to the vault bundle (the dir containing _meta/).
+                         If omitted: uses $VAULT_DIR, else auto-discovers a single
+                         directory containing _meta/vault-config.json.
+  --allow-broken-links   Downgrade broken bundle links and missing manifest files
+                         to warnings. For early build phases only.
+  --strict-orphans       Promote orphan warnings (no inbound links) to errors.
+  --quiet                Print only the summary line.
+  --help, -h             Show this help.
+
+Exit codes:
+  0  no errors (warnings are allowed)
+  1  one or more errors
+`);
+  process.exit(0);
+}
+
+const flagValue = name => {
+  const i = argv.indexOf(name);
+  return i !== -1 && argv[i + 1] && !argv[i + 1].startsWith("--")
+    ? argv[i + 1]
+    : null;
+};
+
+const ALLOW_BROKEN = args.has("--allow-broken-links");
+const STRICT_ORPHANS = args.has("--strict-orphans");
+const QUIET = args.has("--quiet");
+
+// ---------------------------------------------------------------- locate vault
+const CWD = process.cwd();
+const CONFIG_REL = join("_meta", "vault-config.json");
+
+function findVaults(dir, depth, out = []) {
+  if (depth < 0) return out;
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  if (existsSync(join(dir, CONFIG_REL))) out.push(dir);
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    if (["node_modules", ".git", ".next", "dist", "build"].includes(e.name))
+      continue;
+    findVaults(join(dir, e.name), depth - 1, out);
+  }
+  return out;
+}
+
+function resolveVault() {
+  const explicit = flagValue("--vault") ?? process.env.VAULT_DIR;
+  if (explicit) {
+    const abs = resolve(CWD, explicit);
+    if (!existsSync(join(abs, CONFIG_REL))) {
+      console.error(`ERROR no ${CONFIG_REL} under "${explicit}"`);
+      process.exit(1);
+    }
+    return abs;
+  }
+  const found = findVaults(CWD, 4);
+  if (found.length === 1) return found[0];
+  if (found.length === 0) {
+    console.error(
+      `ERROR no vault found (looked for ${CONFIG_REL} up to 4 levels below ${CWD}).\n` +
+        `      Pass --vault <dir> or set VAULT_DIR.`
+    );
+    process.exit(1);
+  }
+  console.error(
+    `ERROR multiple vaults found; pass --vault <dir> to choose:\n` +
+      found.map(f => `      ${relative(CWD, f) || "."}`).join("\n")
+  );
+  process.exit(1);
+}
+
+const VAULT = resolveVault();
+const CONFIG = JSON.parse(readFileSync(join(VAULT, CONFIG_REL), "utf8"));
+
+// Repo root: nearest ancestor with a .git, else the cwd.
+function findRepoRoot(from) {
+  let d = from;
+  for (;;) {
+    if (existsSync(join(d, ".git"))) return d;
+    const up = dirname(d);
+    if (up === d) return CWD;
+    d = up;
+  }
+}
+const REPO_ROOT = findRepoRoot(VAULT);
+
+// Config-declared bundle_root is advisory; warn if it disagrees with reality.
+const declaredRoot = CONFIG.bundle_root;
+const actualRoot = relative(REPO_ROOT, VAULT).split(sep).join("/");
+
+// ---------------------------------------------------------------- rules from config
+const LINK_RULES = CONFIG.link_rules ?? {};
+const FORBIDDEN = new Set(LINK_RULES.forbidden ?? []);
+const CITATIONS_SECTION = LINK_RULES.external_repo_links_only_under ?? "Citations";
+const MAX_DESCRIPTION = CONFIG.frontmatter?.max_description_length ?? 160;
+const MAX_CONCEPT_LINES = CONFIG.max_concept_lines ?? null;
+const PATH_FIELDS = CONFIG.frontmatter?.path_fields ?? [
+  "resource",
+  "sources",
+  "docs",
+];
+
+const errors = [];
+const warnings = [];
+const rel = f => relative(REPO_ROOT, f).split(sep).join("/");
+const err = (file, msg) => errors.push(`${rel(file)}: ${msg}`);
+const warn = (file, msg) => warnings.push(`${rel(file)}: ${msg}`);
+
+if (declaredRoot && declaredRoot !== actualRoot) {
+  warnings.push(
+    `${rel(join(VAULT, CONFIG_REL))}: bundle_root is "${declaredRoot}" but the vault is at "${actualRoot}"`
+  );
+}
+
+// ---------------------------------------------------------------- collect files
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) out.push(...walk(p));
+    else out.push(p);
+  }
+  return out;
+}
+const allFiles = walk(VAULT);
+const mdFiles = allFiles.filter(f => f.endsWith(".md"));
+const canvasFiles = allFiles.filter(f => f.endsWith(".canvas"));
+const inMeta = f => relative(VAULT, f).split(sep)[0] === "_meta";
+const isIndex = f =>
+  f.endsWith(`${sep}index.md`) || f === join(VAULT, "index.md");
+const isLog = f => f === join(VAULT, "log.md");
+const conceptFiles = mdFiles.filter(f => !inMeta(f) && !isIndex(f) && !isLog(f));
+
+// ---------------------------------------------------------------- YAML subset parser
+const unquote = s => (s.startsWith('"') && s.endsWith('"') ? s.slice(1, -1) : s);
+
+function parseFrontmatter(raw, file) {
+  if (!raw.startsWith("---\n")) return null;
+  const end = raw.indexOf("\n---", 4);
+  if (end === -1) {
+    err(file, "unterminated frontmatter block");
+    return null;
+  }
+  const fm = {};
+  let listKey = null;
+  for (const line of raw.slice(4, end).split("\n")) {
+    if (!line.trim() || line.trim().startsWith("#")) continue;
+    const listItem = line.match(/^\s+-\s+(.+)$/);
+    if (listItem && listKey) {
+      fm[listKey].push(unquote(listItem[1].trim()));
+      continue;
+    }
+    const kv = line.match(/^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$/);
+    if (!kv) {
+      err(file, `frontmatter line not in allowed YAML subset: "${line}"`);
+      continue;
+    }
+    const [, key, valRaw] = kv;
+    const val = valRaw.trim();
+    if (val === "") {
+      fm[key] = [];
+      listKey = key;
+    } else if (val.startsWith("[") && val.endsWith("]")) {
+      fm[key] = val
+        .slice(1, -1)
+        .split(",")
+        .map(s => unquote(s.trim()))
+        .filter(Boolean);
+      listKey = null;
+    } else {
+      fm[key] = unquote(val);
+      listKey = null;
+    }
+  }
+  return fm;
+}
+
+const parseTypeQuick = raw => {
+  const m = raw.match(/^---\n[\s\S]*?^type:\s*(.+)$/m);
+  return m ? unquote(m[1].trim()) : null;
+};
+
+// ---------------------------------------------------------------- per-file checks
+const idOf = f => relative(VAULT, f).replace(/\.md$/, "").split(sep).join("/");
+const inbound = new Map(conceptFiles.map(f => [idOf(f), 0]));
+const LINK_RE = /\[([^\]]*)\]\(([^)\s]+)\)/g;
+const WIKILINK_RE = /(^|[^!\[])\[\[([^\]]+)\]\]/g;
+const REPO_HOSTS = /^https?:\/\/(www\.)?(github|gitlab|bitbucket)\.com\//i;
+
+for (const file of mdFiles) {
+  const raw = readFileSync(file, "utf8");
+  const hasFM = raw.startsWith("---\n");
+  const isRoot = file === join(VAULT, "index.md");
+
+  // --- reserved files
+  if (isLog(file)) {
+    if (hasFM) err(file, "log.md must not have frontmatter");
+    if (!/^# /m.test(raw)) err(file, "log.md needs an H1");
+    if (!/^## \d{4}-\d{2}-\d{2}/m.test(raw))
+      warn(file, "log.md has no dated (## YYYY-MM-DD) entries");
+    continue;
+  }
+  if (isIndex(file) && !isRoot && hasFM)
+    err(file, "index.md files must not have frontmatter (reserved-file rule)");
+
+  let fm = null;
+  if (!inMeta(file) && (!isIndex(file) || isRoot)) {
+    fm = parseFrontmatter(raw, file);
+    if (!fm) {
+      err(file, "missing frontmatter");
+      continue;
+    }
+  } else if (inMeta(file)) {
+    fm = parseFrontmatter(raw, file);
+    if (!fm || !fm.type) err(file, "_meta markdown needs frontmatter with a type");
+  }
+
+  const typeCfg = fm ? CONFIG.types[fm.type] : null;
+
+  // --- frontmatter contract (concepts + root index)
+  if (fm && !inMeta(file)) {
+    if (!fm.type) err(file, "missing required field: type");
+    else if (!typeCfg) err(file, `unknown type "${fm.type}"`);
+
+    for (const req of CONFIG.frontmatter.required) {
+      if (isRoot && req === "status") continue;
+      if (fm[req] === undefined || (Array.isArray(fm[req]) && fm[req].length === 0))
+        err(file, `missing required field: ${req}`);
+    }
+    if (isRoot && fm.okf_version !== CONFIG.okf_version)
+      err(file, `root index.md must declare okf_version: "${CONFIG.okf_version}"`);
+    if (!isRoot && fm.okf_version)
+      err(file, "okf_version allowed only in root index.md");
+    if (fm.description && fm.description.length > MAX_DESCRIPTION)
+      err(file, `description is ${fm.description.length} chars (max ${MAX_DESCRIPTION})`);
+    if (fm.timestamp && !/^\d{4}-\d{2}-\d{2}$/.test(fm.timestamp))
+      err(file, `timestamp "${fm.timestamp}" not YYYY-MM-DD`);
+    if (fm.status && !CONFIG.statuses.includes(fm.status))
+      err(file, `invalid status "${fm.status}"`);
+    if (fm.domain && CONFIG.domains?.length && !CONFIG.domains.includes(fm.domain))
+      err(file, `invalid domain "${fm.domain}"`);
+    for (const t of fm.tags ?? [])
+      if (CONFIG.tags?.length && !CONFIG.tags.includes(t))
+        err(file, `tag "${t}" not in controlled vocabulary`);
+    if (typeCfg?.resource_required && !fm.resource)
+      err(file, `type "${fm.type}" requires resource`);
+
+    const known = new Set([
+      ...CONFIG.frontmatter.required,
+      ...CONFIG.frontmatter.optional,
+    ]);
+    for (const k of Object.keys(fm))
+      if (!known.has(k)) warn(file, `unrecognized frontmatter key "${k}"`);
+
+    // --- path fields must exist on disk
+    for (const field of PATH_FIELDS) {
+      const v = fm[field];
+      if (v === undefined) continue;
+      for (const p of Array.isArray(v) ? v : [v]) {
+        if (!p || /^https?:\/\//.test(p)) continue;
+        if (!existsSync(resolve(REPO_ROOT, p)))
+          err(file, `${field} path does not exist: "${p}"`);
+      }
+    }
+
+    // --- section structure
+    if (typeCfg && !typeCfg.internal && typeCfg.sections.length > 0 && !isRoot) {
+      const h2s = [...raw.matchAll(/^## (.+)$/gm)].map(m => m[1].trim());
+      const want = typeCfg.sections;
+      if (JSON.stringify(h2s) !== JSON.stringify(want))
+        err(file, `H2 sections [${h2s.join(" | ")}] != template [${want.join(" | ")}]`);
+      const h1s = [...raw.matchAll(/^# (.+)$/gm)];
+      if (h1s.length !== 1) err(file, `expected exactly 1 H1, found ${h1s.length}`);
+    }
+
+    // --- map-card length budget (advisory).
+    // Free-form types (zero declared sections, e.g. `guide`) are navigation, not map-cards.
+    const freeForm = !typeCfg || typeCfg.sections.length === 0;
+    if (MAX_CONCEPT_LINES && !isRoot && !isIndex(file) && !freeForm) {
+      const lines = raw.split("\n").length;
+      if (lines > MAX_CONCEPT_LINES)
+        warn(file, `${lines} lines (map-card budget is ${MAX_CONCEPT_LINES}) — summarize and link instead`);
+    }
+  }
+
+  if (inMeta(file)) continue;
+
+  // --- links
+  const bodyStart = hasFM ? raw.indexOf("\n---", 4) + 4 : 0;
+  const body = raw.slice(bodyStart);
+  const fmType = fm?.type ?? parseTypeQuick(raw);
+  const exempt = isIndex(file) || fmType === "guide";
+  let currentH2 = "";
+  let citesOutOfBundle = false;
+
+  for (const line of body.split("\n")) {
+    const h2 = line.match(/^## (.+)$/);
+    if (h2) currentH2 = h2[1].trim();
+
+    if (FORBIDDEN.has("wikilinks"))
+      for (const m of line.matchAll(WIKILINK_RE))
+        err(file, `wikilink "[[${m[2]}]]" — use relative markdown links`);
+
+    for (const m of line.matchAll(LINK_RE)) {
+      const target = m[2];
+
+      if (/^(https?:)?\/\//.test(target) || target.startsWith("mailto:")) {
+        if (FORBIDDEN.has("github-urls-for-repo-files") && REPO_HOSTS.test(target)) {
+          const looksLikeThisRepo = /\/(blob|tree|raw)\//.test(target);
+          if (looksLikeThisRepo)
+            err(file, `repo-host URL "${target}" — reference repo files by path, not URL`);
+        }
+        if (currentH2 === CITATIONS_SECTION) citesOutOfBundle = true;
+        continue;
+      }
+      if (target.startsWith("#")) continue;
+      if (target.startsWith("/")) {
+        err(file, `leading-slash link "${target}" (use relative paths)`);
+        continue;
+      }
+
+      const clean = target.split("#")[0];
+      if (![".md", ".canvas", ".base", ".json"].some(e => clean.endsWith(e))) {
+        warn(file, `link to non-md target "${target}"`);
+        continue;
+      }
+
+      const abs = resolve(dirname(file), clean);
+      const insideBundle = !relative(VAULT, abs).startsWith("..");
+      if (insideBundle) {
+        if (!existsSync(abs)) {
+          (ALLOW_BROKEN ? warn : err)(file, `broken bundle link "${target}"`);
+        } else if (abs.endsWith(".md") && inbound.has(idOf(abs))) {
+          inbound.set(idOf(abs), inbound.get(idOf(abs)) + 1);
+        }
+      } else {
+        if (relative(REPO_ROOT, abs).startsWith("..")) {
+          err(file, `link escapes repository: "${target}"`);
+          continue;
+        }
+        if (!existsSync(abs)) err(file, `broken citation link "${target}"`);
+        if (currentH2 === CITATIONS_SECTION) citesOutOfBundle = true;
+        if (!exempt && currentH2 !== CITATIONS_SECTION)
+          err(
+            file,
+            `out-of-bundle link "${target}" outside "## ${CITATIONS_SECTION}" (found under "${currentH2 || "preamble"}")`
+          );
+      }
+    }
+  }
+
+  // --- stub types must actually cite their source of truth
+  if (typeCfg?.stub && !citesOutOfBundle)
+    err(
+      file,
+      `type "${fmType}" is a stub: it must cite its source-of-truth doc under "## ${CITATIONS_SECTION}"`
+    );
+}
+
+// ---------------------------------------------------------------- canvas nodes
+for (const file of canvasFiles) {
+  let canvas;
+  try {
+    canvas = JSON.parse(readFileSync(file, "utf8"));
+  } catch (e) {
+    err(file, `canvas is not valid JSON: ${e.message}`);
+    continue;
+  }
+  for (const node of canvas.nodes ?? []) {
+    if (node.type !== "file" || !node.file) continue;
+    // Canvas file paths are Obsidian-vault-relative; try vault, then bundle, then repo.
+    const candidates = [
+      resolve(dirname(VAULT), node.file),
+      resolve(VAULT, node.file),
+      resolve(REPO_ROOT, node.file),
+    ];
+    if (!candidates.some(existsSync))
+      err(file, `canvas node references missing file "${node.file}"`);
+  }
+}
+
+// ---------------------------------------------------------------- manifest sync
+const manifestPath = join(VAULT, "_meta", "manifest.json");
+if (existsSync(manifestPath)) {
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const entries = manifest.concepts ?? manifest;
+  const diskIds = new Set(conceptFiles.map(idOf));
+  const manIds = new Set(entries.map(e => e.id));
+  for (const e of entries)
+    if (!diskIds.has(e.id))
+      (ALLOW_BROKEN ? warn : err)(
+        manifestPath,
+        `manifest concept "${e.id}" missing on disk`
+      );
+  // Always an error: the manifest is the ID registry that prevents invented links,
+  // so a file it does not know about is a hole in the allowlist.
+  for (const id of diskIds)
+    if (!manIds.has(id)) err(manifestPath, `file "${id}.md" not in manifest`);
+}
+
+// ---------------------------------------------------------------- orphans
+for (const [id, count] of inbound)
+  if (count === 0)
+    (STRICT_ORPHANS ? err : warn)(
+      join(VAULT, `${id}.md`),
+      "orphan: no inbound links"
+    );
+
+// ---------------------------------------------------------------- report
+if (!QUIET) {
+  for (const w of warnings) console.log(`WARN  ${w}`);
+  for (const e of errors) console.log(`ERROR ${e}`);
+}
+console.log(
+  `vault(${actualRoot || "."}): ${conceptFiles.length} concepts / ${mdFiles.length} md files` +
+    `${canvasFiles.length ? ` / ${canvasFiles.length} canvases` : ""}` +
+    ` — ${errors.length} errors, ${warnings.length} warnings` +
+    (ALLOW_BROKEN ? " (broken links allowed)" : "")
+);
+process.exit(errors.length ? 1 : 0);

--- a/knowledge-vault/templates/github/validate-vault.yml
+++ b/knowledge-vault/templates/github/validate-vault.yml
@@ -1,0 +1,49 @@
+# Opt-in CI gate for an OKF knowledge vault.
+#
+# Copy to .github/workflows/validate-vault.yml and set VAULT_DIR below.
+#
+# Why this exists: in the project this method came from, the validator was written, passed
+# locally, and was wired into no workflow at all — so vault drift was invisible to CI and an
+# audit had to catch it. A gate that nothing runs is not a gate. Do not inherit that.
+
+name: Validate Knowledge Vault
+
+on:
+  pull_request:
+    paths:
+      # The vault itself
+      - "{{VAULT_DIR}}/**"
+      # The validator and its config
+      - "knowledge-vault/scripts/validate-vault.mjs"
+      # Add the source paths your concepts claim to describe, so a code change that
+      # invalidates a concept also trips this workflow. Mirror your vault-sync watch-list.
+      # - "src/**"
+      # - "docs/**"
+  push:
+    branches: ["{{MAIN_BRANCH}}"]
+    paths:
+      - "{{VAULT_DIR}}/**"
+      - "knowledge-vault/scripts/validate-vault.mjs"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Structural validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      # No install step: the validator uses node: builtins only.
+      - name: Validate vault structure
+        run: node knowledge-vault/scripts/validate-vault.mjs --vault "{{VAULT_DIR}}"
+
+      # Recommended: also lint the vault's markdown. Uncomment once you have a config.
+      # - name: Lint vault markdown
+      #   run: npx --yes markdownlint-cli2 "{{VAULT_DIR}}/**/*.md"

--- a/knowledge-vault/templates/github/validate-vault.yml
+++ b/knowledge-vault/templates/github/validate-vault.yml
@@ -36,9 +36,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # If your repo has no .nvmrc, drop node-version-file and keep node-version.
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          node-version: "20"
 
       # No install step: the validator uses node: builtins only.
       - name: Validate vault structure

--- a/knowledge-vault/templates/github/validate-vault.yml
+++ b/knowledge-vault/templates/github/validate-vault.yml
@@ -36,10 +36,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # If your repo has no .nvmrc, drop node-version-file and keep node-version.
+      # Pins a version that works everywhere. If your repo has an .nvmrc and you want CI to
+      # follow it, REPLACE node-version with node-version-file — do not set both: when both
+      # are supplied setup-node uses node-version and silently ignores the file.
+      #   node-version-file: ".nvmrc"
       - uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
           node-version: "20"
 
       # No install step: the validator uses node: builtins only.

--- a/knowledge-vault/templates/obsidian/app.json
+++ b/knowledge-vault/templates/obsidian/app.json
@@ -1,0 +1,10 @@
+{
+  "newLinkFormat": "relative",
+  "useMarkdownLinks": true,
+  "alwaysUpdateLinks": true,
+  "showUnsupportedFiles": false,
+  "attachmentFolderPath": "starter-bundle/maps/assets",
+  "userIgnoreFilters": [
+    "starter-bundle/_meta/templates/"
+  ]
+}

--- a/knowledge-vault/templates/obsidian/core-plugins.json
+++ b/knowledge-vault/templates/obsidian/core-plugins.json
@@ -1,0 +1,19 @@
+{
+  "file-explorer": true,
+  "global-search": true,
+  "switcher": true,
+  "graph": true,
+  "backlink": true,
+  "outgoing-link": true,
+  "tag-pane": true,
+  "properties": true,
+  "page-preview": true,
+  "canvas": true,
+  "bases": true,
+  "bookmarks": true,
+  "outline": true,
+  "word-count": false,
+  "file-recovery": true,
+  "daily-notes": false,
+  "templates": false
+}

--- a/knowledge-vault/templates/obsidian/graph.json
+++ b/knowledge-vault/templates/obsidian/graph.json
@@ -1,0 +1,51 @@
+{
+  "collapse-filter": false,
+  "search": "",
+  "showTags": false,
+  "showAttachments": false,
+  "hideUnresolved": false,
+  "showOrphans": true,
+  "collapse-color-groups": false,
+  "colorGroups": [
+    {
+      "query": "path:starter-bundle/architecture",
+      "color": { "a": 1, "rgb": 5431378 }
+    },
+    {
+      "query": "path:starter-bundle/domains",
+      "color": { "a": 1, "rgb": 11621088 }
+    },
+    {
+      "query": "path:starter-bundle/integrations",
+      "color": { "a": 1, "rgb": 14832298 }
+    },
+    {
+      "query": "path:starter-bundle/operations",
+      "color": { "a": 1, "rgb": 15904854 }
+    },
+    {
+      "query": "path:starter-bundle/knowledge",
+      "color": { "a": 1, "rgb": 9146239 }
+    },
+    {
+      "query": "path:starter-bundle/process",
+      "color": { "a": 1, "rgb": 6604450 }
+    },
+    {
+      "query": "-path:starter-bundle",
+      "color": { "a": 1, "rgb": 8947848 }
+    }
+  ],
+  "collapse-display": false,
+  "showArrow": true,
+  "textFadeMultiplier": 0,
+  "nodeSizeMultiplier": 1.2,
+  "lineSizeMultiplier": 1,
+  "collapse-forces": false,
+  "centerStrength": 0.5,
+  "repelStrength": 12,
+  "linkStrength": 1,
+  "linkDistance": 250,
+  "scale": 0.6,
+  "close": false
+}

--- a/knowledge-vault/templates/starter-bundle/.markdownlint.json
+++ b/knowledge-vault/templates/starter-bundle/.markdownlint.json
@@ -1,0 +1,31 @@
+{
+  "_comment": [
+    "Markdown lint config for this vault bundle. It ships INSIDE the bundle so it travels",
+    "with you when you copy it — CONVENTIONS.md describes the rules below, and a claim about",
+    "enforcement is only true if the config that backs it comes along.",
+    "",
+    "Self-contained on purpose: no 'extends', so it works wherever you put the bundle.",
+    "",
+    "MD025 front_matter_title: a concept legitimately has BOTH a frontmatter title and an H1.",
+    "MD024 siblings_only: every concept has an '## Overview', which is fine across files.",
+    "MD040 / MD055 / MD056: the formatting rules CONVENTIONS.md claims — enabled so the claim",
+    "is actually enforced rather than aspirational."
+  ],
+
+  "default": true,
+
+  "MD013": {
+    "line_length": 120,
+    "code_blocks": false,
+    "tables": false
+  },
+
+  "MD024": { "siblings_only": true },
+  "MD025": { "front_matter_title": "" },
+  "MD040": true,
+  "MD055": { "style": "leading_and_trailing" },
+  "MD056": true,
+
+  "MD033": false,
+  "MD041": false
+}

--- a/knowledge-vault/templates/starter-bundle/_meta/CONVENTIONS.md
+++ b/knowledge-vault/templates/starter-bundle/_meta/CONVENTIONS.md
@@ -14,13 +14,19 @@ and doubles as an Obsidian vault. **Every rule here exists to keep hundreds of f
 many agents indistinguishable from files written by one mind.** The machine-readable form of this
 document is `vault-config.json`.
 
-**What enforces what.** `validate-vault.mjs` enforces the structural rules: the frontmatter
-contract, section order, link legality, path existence, the stub contract, and manifest agreement.
-Markdown lint enforces the formatting rules (line length, table pipes, fenced-block languages).
-A handful of rules below are **conventions only** — kebab-case filenames, no emoji, one-sentence
-descriptions, `verified_against` actually being a SHA, and newest-first log ordering. Nothing
-checks those; they rely on review. Do not assume a clean validator run means every rule here was
-followed.
+**What enforces what.** Be precise about this, because a rule nobody checks is a wish.
+
+- **`validate-vault.mjs`** enforces the structural rules: the frontmatter contract, section order,
+  link legality, path existence, the stub contract, and manifest agreement.
+- **Markdown lint** enforces the formatting rules — line length, fenced-block languages, and table
+  pipes — via `.markdownlint.json`, which ships **inside this bundle** so it travels with you when
+  you copy it. Those three rules are only real because that config comes along; if you drop it, the
+  claims in *Body style* become aspirational.
+- **Convention only, nothing checks these:** kebab-case filenames, no emoji, one-sentence
+  descriptions, `verified_against` actually being a git SHA, and newest-first ordering in `log.md`.
+  They rely on review.
+
+Do not read a clean validator run as "every rule here was followed."
 
 ## Concept files
 

--- a/knowledge-vault/templates/starter-bundle/_meta/CONVENTIONS.md
+++ b/knowledge-vault/templates/starter-bundle/_meta/CONVENTIONS.md
@@ -1,0 +1,109 @@
+---
+type: meta
+title: "Conventions"
+description: "The constitution for this OKF bundle: frontmatter contract, link rules, section templates, style."
+tags: [okf]
+timestamp: 2026-07-19
+status: active
+---
+
+# Conventions
+
+This bundle conforms to the [Open Knowledge Format v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+and doubles as an Obsidian vault. **Every rule here exists to keep hundreds of files written by
+many agents indistinguishable from files written by one mind.** The machine-readable form of this
+document is `vault-config.json`, enforced by `validate-vault.mjs`.
+
+## Concept files
+
+- One concept per `.md` file. The concept ID is its bundle-relative path minus `.md`.
+- Filenames are kebab-case.
+- Exactly one H1: the concept title. All sections are H2. (OKF suggests `#` headings for
+  sections; we use H2 so markdown linters that forbid multiple H1s stay happy. Heading level is
+  soft guidance in OKF.)
+- Every concept ends with `## Citations`.
+
+## Frontmatter contract
+
+**Required on every concept:** `type`, `title`, `description` (one sentence, ≤160 chars), `tags`
+(at least one, from the controlled vocabulary), `timestamp`, `status`.
+
+`timestamp` is **the date the concept was last verified against its sources** — not the date the
+file was edited. That distinction is the whole point.
+
+**Optional:** `resource` (the primary underlying asset, repo-root-relative — required for concrete
+types), `domain`, `ticket`, `sources` (additional assets), `docs` (source-of-truth docs),
+`verified_against` (the git SHA the claims were checked at). `okf_version` appears only in the
+root `index.md`.
+
+**YAML subset only.** The validator parses frontmatter without a YAML library, so: scalar values,
+double-quoted strings, inline lists `[a, b]`, and two-space-indented block lists. No nested maps,
+no multiline scalars. This restriction is what keeps the validator dependency-free.
+
+```yaml
+---
+type: integration
+title: "Payment Provider"
+description: "Handles checkout sessions and settlement webhooks for paid plans."
+resource: "src/integrations/payments/client.ts"
+tags: [platform, api]
+timestamp: 2026-07-19
+status: active
+domain: platform
+ticket: [ABC-123]
+sources:
+  - "src/integrations/payments/webhook.ts"
+docs:
+  - "docs/payments-overview.md"
+verified_against: "a1b2c3d"
+---
+```
+
+## Link rules
+
+1. **Relative markdown links only.** Never wikilinks, never leading-slash paths, never
+   repository-host URLs for files that live in this repo.
+2. **Concept-to-concept links never leave the bundle.** Link text is the target's title, or a
+   natural inline phrase.
+3. **Links that leave the bundle appear only under `## Citations`** — plus in `index.md` files and
+   `guide` concepts, which are navigation. Code files are never linked; they are named as plain
+   inline code, or carried in `resource` / `sources`.
+4. **Link only to concept IDs listed in `manifest.json`.** If a concept you want does not exist,
+   name it in prose without a link and report it as a suggestion. **Never invent links.** This is
+   the rule that makes parallel multi-agent authoring produce a coherent graph instead of a
+   plausible-looking mess.
+5. External web URLs: only under `## Citations`.
+
+## Reserved files
+
+- `index.md` — navigation only, no frontmatter. The root `index.md` is the single exception: it
+  carries `okf_version` plus the standard fields. Not a concept.
+- `log.md` — one changelog at the bundle root. `# Log`, then `## YYYY-MM-DD` entries, newest
+  first. Each entry: what changed, why (ticket), and the source SHA.
+
+## Body style
+
+- **Summarize, never duplicate.** If the knowledge lives in a source-of-truth document, the
+  concept is a map-card that cites it. **If you are restating more than a paragraph, stop and
+  link.**
+- **Facts must be true of the code as it exists.** Name the helper actually called, not the one
+  the code *should* call. When code contradicts documentation, **the code wins** and the
+  discrepancy is noted.
+- Environment variable names may be mentioned; values never.
+- Keep lines readable; tables need leading and trailing pipes; fenced blocks declare a language.
+- No emoji in concept files.
+
+## Section templates
+
+Each type's required H2 set is defined in `vault-config.json` and mirrored as a skeleton in
+`templates/`. **Section order is fixed** — do not add, remove, or rename H2s. H3s inside a section
+are free. The `guide` type is free-form.
+
+## Change protocol
+
+Every pull request that touches the vault prepends a dated entry to `log.md` and bumps the
+`timestamp` of each concept it re-verified. Deprecation is `status: deprecated` plus a log entry;
+deletion happens only in a follow-up change, after inbound links are cleaned.
+
+**A citation is not re-verification.** Linking a concept from somewhere new does not make its
+claims fresher. Only re-deriving it from source bumps `timestamp` and `verified_against`.

--- a/knowledge-vault/templates/starter-bundle/_meta/CONVENTIONS.md
+++ b/knowledge-vault/templates/starter-bundle/_meta/CONVENTIONS.md
@@ -12,7 +12,15 @@ status: active
 This bundle conforms to the [Open Knowledge Format v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
 and doubles as an Obsidian vault. **Every rule here exists to keep hundreds of files written by
 many agents indistinguishable from files written by one mind.** The machine-readable form of this
-document is `vault-config.json`, enforced by `validate-vault.mjs`.
+document is `vault-config.json`.
+
+**What enforces what.** `validate-vault.mjs` enforces the structural rules: the frontmatter
+contract, section order, link legality, path existence, the stub contract, and manifest agreement.
+Markdown lint enforces the formatting rules (line length, table pipes, fenced-block languages).
+A handful of rules below are **conventions only** — kebab-case filenames, no emoji, one-sentence
+descriptions, `verified_against` actually being a SHA, and newest-first log ordering. Nothing
+checks those; they rely on review. Do not assume a clean validator run means every rule here was
+followed.
 
 ## Concept files
 
@@ -21,7 +29,8 @@ document is `vault-config.json`, enforced by `validate-vault.mjs`.
 - Exactly one H1: the concept title. All sections are H2. (OKF suggests `#` headings for
   sections; we use H2 so markdown linters that forbid multiple H1s stay happy. Heading level is
   soft guidance in OKF.)
-- Every concept ends with `## Citations`.
+- Every sectioned concept ends with `## Citations`. (Free-form types such as `guide` declare no
+  fixed sections and are exempt — see Section templates.)
 
 ## Frontmatter contract
 

--- a/knowledge-vault/templates/starter-bundle/_meta/manifest.json
+++ b/knowledge-vault/templates/starter-bundle/_meta/manifest.json
@@ -1,0 +1,43 @@
+{
+  "okf_version": "0.1",
+  "generated": "2026-07-19",
+  "baseline_sha": "0000000",
+  "concept_count": 2,
+
+  "_readme": [
+    "The manifest has three jobs:",
+    "  1. ID REGISTRY — the allowlist of concept IDs. Generation agents may link ONLY to IDs",
+    "     listed here. This is what stops parallel agents inventing plausible-but-broken links.",
+    "  2. REVERSE INDEX — 'sources' maps source files back to the concepts that describe them,",
+    "     which is how drift detection knows what a given code change made stale.",
+    "  3. DRIFT BASELINE — 'baseline_sha' is the commit the whole vault was last verified against.",
+    "",
+    "'notes' carries the extraction-phase fact digest so generation agents get pre-digested facts",
+    "without re-reading source. 'batch' records which generation lane produced the concept.",
+    "",
+    "Set baseline_sha to a real short SHA on your first build."
+  ],
+
+  "concepts": [
+    {
+      "id": "start-here",
+      "type": "guide",
+      "title": "Start Here",
+      "path": "start-here.md",
+      "description": "The ordered path through this vault for someone new to the system.",
+      "tags": ["onboarding"],
+      "batch": "navigation"
+    },
+    {
+      "id": "process/vault-maintenance",
+      "type": "process",
+      "title": "Vault Maintenance",
+      "path": "process/vault-maintenance.md",
+      "description": "How this vault stays honest as the code moves.",
+      "tags": ["process", "okf"],
+      "domain": "platform",
+      "notes": "drift = git diff baseline_sha..HEAD over watch-list | stale iff changed path matches resource or sources | deleted source -> status: deprecated, never delete",
+      "batch": "process"
+    }
+  ]
+}

--- a/knowledge-vault/templates/starter-bundle/_meta/templates/adr.md
+++ b/knowledge-vault/templates/starter-bundle/_meta/templates/adr.md
@@ -1,0 +1,45 @@
+---
+type: adr
+title: "{{Title}}"
+description: "{{ONE_SENTENCE ≤160 chars: the decision made, stated as an outcome}}"
+resource: "{{PATH}}"
+tags: [{{TAGS}}, ssot-stub]
+timestamp: {{YYYY-MM-DD}}
+status: active
+domain: {{DOMAIN}}
+ticket: [{{TICKET_IDS}}]
+docs:
+  - "{{PATH}}"
+---
+
+# {{Title}}
+
+**This is a map-card. The full architecture decision record lives in the document cited below —
+do not restate its context, options, or consequences here.** The card exists so the decision is
+discoverable from the graph; the record exists so it is understandable.
+
+## Overview
+
+{{2-4 sentences: the problem that forced a decision and the constraint that dominated it. Enough
+context that a reader knows whether this decision affects them.}}
+
+## Decision
+
+{{2-4 sentences or 2-4 bullets: what was decided, stated in the active voice and the present
+tense ("the system uses X"). Include the one alternative that was closest and the single reason it
+lost. Record the status if the ADR has been superseded.}}
+
+## Affected Concepts
+
+{{2-6 bullets: the concepts this decision constrains, each with a clause on how. Link only to
+concept IDs listed in manifest.json — if the concept does not exist yet, name it in prose without
+a link and report it as a suggestion. Never invent links.}}
+
+- {{[Concept Title](../path/to/concept.md) — what this decision imposes on it}}
+
+## Citations
+
+{{1-4 bullets. A stub type MUST carry an out-of-bundle citation to its source of truth — the
+validator enforces this. Out-of-bundle links appear ONLY in this section.}}
+
+- [{{ADR Document}}]({{PATH}}) — the full record

--- a/knowledge-vault/templates/starter-bundle/_meta/templates/agent-role.md
+++ b/knowledge-vault/templates/starter-bundle/_meta/templates/agent-role.md
@@ -1,0 +1,54 @@
+---
+type: agent-role
+title: "{{Title}}"
+description: "{{ONE_SENTENCE ≤160 chars: what this agent role is accountable for}}"
+resource: "{{PATH}}"
+tags: [agents, {{TAGS}}, ssot-stub]
+timestamp: {{YYYY-MM-DD}}
+status: active
+domain: {{DOMAIN}}
+docs:
+  - "{{PATH}}"
+---
+
+# {{Title}}
+
+**This is a map-card. The role's full instructions live in the agent definition cited below — do
+not restate its prompt here.** The card places the role in the workflow graph; the definition
+tells the agent what to do.
+
+## Overview
+
+{{3-5 sentences: the role's purpose, where it sits in the delivery flow, and the single boundary
+that matters most (what it must never do). Refer to roles by function, never by personal name.}}
+
+## Responsibilities
+
+{{3-6 bullets: what this role owns, phrased as accountabilities rather than activities. Include at
+least one explicit non-responsibility — boundaries prevent role bleed more effectively than duty
+lists do.}}
+
+- {{Owns: ...}}
+- {{Does not: ...}}
+
+## Skills & SOPs
+
+{{2-6 bullets: the skills this role invokes and the SOPs it operates under. Link only to concept
+IDs listed in manifest.json; name missing ones in prose without a link. Never invent links.}}
+
+- {{[Skill Title](../path/to/skill.md) — when this role reaches for it}}
+
+## Handoffs
+
+{{2-5 bullets: the exit state this role produces, who receives it, and what evidence must
+accompany the handoff. Name the upstream role that feeds this one.}}
+
+- **{{Receives from}}** {{role}} — {{what arrives, and the precondition that must hold}}
+- **{{Hands off to}}** {{role}} — {{the exit state and the evidence required}}
+
+## Citations
+
+{{1-4 bullets. A stub type MUST carry an out-of-bundle citation to its source of truth — the
+validator enforces this. Out-of-bundle links appear ONLY in this section.}}
+
+- [{{Agent Definition}}]({{PATH}}) — the authoritative role specification

--- a/knowledge-vault/templates/starter-bundle/_meta/templates/architecture.md
+++ b/knowledge-vault/templates/starter-bundle/_meta/templates/architecture.md
@@ -1,0 +1,48 @@
+---
+type: architecture
+title: "{{Title}}"
+description: "{{ONE_SENTENCE ≤160 chars: the structural idea or cross-cutting view this concept explains}}"
+tags: [{{TAGS}}]
+timestamp: {{YYYY-MM-DD}}
+status: active
+domain: {{DOMAIN}}
+docs:
+  - "{{PATH}}"
+verified_against: "{{GIT_SHA}}"
+---
+
+# {{Title}}
+
+{{2-4 sentences: the architectural idea and why it exists. A reader who stops here should be able
+to describe the shape of the system in one breath.}}
+
+## Overview
+
+{{3-5 sentences: the problem this structure solves and the constraints that forced it. Facts must
+be true of the code as it exists — name the helper actually called, not the one the code should
+call. When code contradicts documentation, the code wins and the discrepancy is noted here.}}
+
+## Design
+
+{{4-8 bullets or a short table: the components, their responsibilities, and how they interact.
+Use a table only when it beats prose; tables need leading and trailing pipes with single-space
+padding. Fenced blocks must declare a language. Environment variable names may appear; values
+never.}}
+
+| Component | Responsibility | Notes |
+| --- | --- | --- |
+| {{name}} | {{one clause}} | {{constraint or caveat}} |
+
+## Related Concepts
+
+{{3-6 bullets: neighbouring concepts and the nature of the relationship (depends on, constrains,
+is implemented by). Link only to concept IDs listed in manifest.json; name missing ones in prose.}}
+
+- {{[Concept Title](../path/to/concept.md) — how it relates}}
+
+## Citations
+
+{{1-5 bullets: the source-of-truth documents and any external references. Out-of-bundle links
+appear ONLY in this section. Relative markdown links only.}}
+
+- [{{Doc Title}}]({{PATH}}) — {{what it authoritatively covers}}

--- a/knowledge-vault/templates/starter-bundle/_meta/templates/domain.md
+++ b/knowledge-vault/templates/starter-bundle/_meta/templates/domain.md
@@ -1,0 +1,43 @@
+---
+type: domain
+title: "{{Title}}"
+description: "{{ONE_SENTENCE ≤160 chars: what this business domain covers and where its boundary falls}}"
+tags: [{{TAGS}}]
+timestamp: {{YYYY-MM-DD}}
+status: active
+domain: {{DOMAIN}}
+verified_against: "{{GIT_SHA}}"
+---
+
+# {{Title}}
+
+{{2-4 sentences: the domain in plain language — what capability it delivers and for whom. This is
+the semantic axis: it re-groups artifacts by purpose, so a newcomer who asks "how does X work"
+lands here rather than in a directory listing.}}
+
+## Overview
+
+{{3-5 sentences: the domain's responsibility and its boundary. State explicitly what is NOT in it
+and which neighbouring domain owns that instead. Boundaries are the whole value of a domain card.}}
+
+## Members
+
+{{5-12 bullets: the concepts that constitute this domain, each with a short clause saying why it
+belongs. Link only to concept IDs listed in manifest.json — if a member concept does not exist
+yet, name it in prose without a link and report it as a suggestion. Never invent links.}}
+
+- {{[Concept Title](../path/to/concept.md) — one clause on its role in this domain}}
+
+## Key Flows
+
+{{2-4 flows, each 1-3 lines: the end-to-end paths that cross this domain, written as a traced
+sequence (entry point, to handler, to store). Name real artifacts. Prefer one fully-traced flow
+over four vague ones.}}
+
+## Citations
+
+{{1-5 bullets: source-of-truth documents and external references. Out-of-bundle links appear ONLY
+in this section — everywhere else, links must stay inside the bundle. Relative markdown links
+only: no wikilinks, no leading-slash paths, no repository-host URLs for files in this repo.}}
+
+- [{{Doc Title}}]({{PATH}}) — {{what it authoritatively covers}}

--- a/knowledge-vault/templates/starter-bundle/_meta/templates/environment.md
+++ b/knowledge-vault/templates/starter-bundle/_meta/templates/environment.md
@@ -1,0 +1,46 @@
+---
+type: environment
+title: "{{Title}}"
+description: "{{ONE_SENTENCE ≤160 chars: which environment this is and what it is for}}"
+tags: [{{TAGS}}]
+timestamp: {{YYYY-MM-DD}}
+status: active
+domain: {{DOMAIN}}
+sources:
+  - "{{PATH}}"
+verified_against: "{{GIT_SHA}}"
+---
+
+# {{Title}}
+
+{{2-4 sentences: what this environment is, who uses it, and the one thing people most often get
+wrong about it (for example, mistaking it for a mirror of production when it is not).}}
+
+## Overview
+
+{{3-5 sentences: the environment's purpose in the delivery flow and how it differs from its
+neighbours — data realism, credentials, scale, and what guarantees it does NOT provide.}}
+
+## Topology
+
+{{4-8 bullets or a table: the services that make it up, how they are hosted, and how they connect.
+Use a table when there are more than four services; tables need leading and trailing pipes.}}
+
+| Service | Host / Port | Notes |
+| --- | --- | --- |
+| {{name}} | {{where it runs}} | {{version or constraint}} |
+
+## Access & Deployment
+
+{{4-8 bullets: how a person or agent reaches this environment, what credential or network access is
+required, and how code arrives here (automatic on merge, manual promotion, image pull). State
+whether deploys are automatic or manual — that distinction causes the most confusion. Names of
+environment variables may appear; values never.}}
+
+## Citations
+
+{{1-5 bullets: runbooks, access procedures, and infrastructure configuration documents.
+Out-of-bundle links appear ONLY in this section. Relative markdown links only — no leading-slash
+paths, no repository-host URLs for files in this repo.}}
+
+- [{{Doc Title}}]({{PATH}}) — {{what it authoritatively covers}}

--- a/knowledge-vault/templates/starter-bundle/_meta/templates/guide.md
+++ b/knowledge-vault/templates/starter-bundle/_meta/templates/guide.md
@@ -1,0 +1,56 @@
+---
+type: guide
+title: "{{Title}}"
+description: "{{ONE_SENTENCE ≤160 chars: what a reader will be able to do after reading this}}"
+tags: [{{TAGS}}]
+timestamp: {{YYYY-MM-DD}}
+status: active
+domain: {{DOMAIN}}
+docs:
+  - "{{PATH}}"
+---
+
+# {{Title}}
+
+**The `guide` type is free-form: it declares no fixed sections, so the H2 structure is yours to
+choose.** Guides are the learning door of the vault — narrative and navigational, where the other
+types are reference cards. Everything below is guidance, not a required skeleton. Delete what does
+not serve the reader.
+
+Guides carry one privilege no other type has: **they may link outside the bundle anywhere in the
+body**, because navigation is their job. Every other rule still holds — relative markdown links
+only, no wikilinks, no leading-slash paths, no repository-host URLs for files in this repo, and
+never a link to a concept ID that is absent from `manifest.json`.
+
+## Shape that usually works
+
+{{Open with 2-4 sentences naming the audience and the outcome. A reader must be able to tell in
+ten seconds whether this guide is for them.}}
+
+{{Then 3-7 H2 sections of 3-8 sentences or 4-8 bullets each. Order them by the reader's journey,
+not by the system's structure.}}
+
+{{Where you send the reader elsewhere, state WHY it comes at that point. "Read the security model
+third" is a table of contents; "read it third because everything after it assumes it" is
+onboarding. That clause is the teaching.}}
+
+{{Close with a short list of next steps or related reading.}}
+
+## Budgets and discipline
+
+- **Length.** Guides may exceed the map-card budget in `vault-config.json`; the validator will
+  warn, and for this type the warning is acceptable. Aim to stay under roughly 200 lines anyway.
+- **Summarize, never duplicate.** If a procedure lives in a source-of-truth document, describe
+  what it accomplishes and link it. If you are restating more than a paragraph, stop and link.
+- **Code wins over docs.** Facts must be true of the system as it exists. A guide that describes
+  the intended design rather than the built one is the most damaging file in the vault.
+- **Freshness.** `timestamp` is the date the content was last verified against its sources — not
+  the date the file was edited. A citation is not re-verification.
+- No emoji. Environment variable names may appear; values never.
+
+## Citations
+
+{{Optional for this type, since guides may link inline. Include it when the guide rests on
+specific source-of-truth documents worth naming as authorities.}}
+
+- [{{Doc Title}}]({{PATH}}) — {{what it authoritatively covers}}

--- a/knowledge-vault/templates/starter-bundle/_meta/templates/integration.md
+++ b/knowledge-vault/templates/starter-bundle/_meta/templates/integration.md
@@ -1,0 +1,52 @@
+---
+type: integration
+title: "{{Title}}"
+description: "{{ONE_SENTENCE ≤160 chars: which external system this integrates and what it does for us}}"
+resource: "{{PATH}}"
+tags: [{{TAGS}}]
+timestamp: {{YYYY-MM-DD}}
+status: active
+domain: {{DOMAIN}}
+sources:
+  - "{{PATH}}"
+verified_against: "{{GIT_SHA}}"
+---
+
+# {{Title}}
+
+{{2-4 sentences: what the external system is, what capability it provides, and what breaks without
+it. Use neutral naming — "the auth provider", "the primary datastore" — unless the vendor name is
+itself the fact.}}
+
+## Overview
+
+{{3-5 sentences: the shape of the integration — direction of calls, whether it is synchronous or
+event-driven, and which parts of the system depend on it.}}
+
+## Touchpoints
+
+{{4-8 bullets or a table: every place the codebase meets this system — client wrappers, webhook
+receivers, scheduled syncs. Name real files as plain inline code; never link to code files. Code
+paths belong in `resource` and `sources`.}}
+
+| Touchpoint | Direction | Artifact |
+| --- | --- | --- |
+| {{what it does}} | {{inbound / outbound}} | `{{PATH}}` |
+
+## Configuration
+
+{{3-6 bullets: the environment variables, feature flags, and setup steps required. Names only —
+never values, never secrets. Note which are required versus optional and what degrades if absent.}}
+
+## Failure Modes & Health
+
+{{3-6 bullets: how this integration fails, how the failure surfaces, and what the system does
+about it (retry, queue, degrade, hard-fail). Include the health check or signal to watch. Describe
+the behaviour that exists, not the behaviour that ought to exist.}}
+
+## Citations
+
+{{1-5 bullets: source-of-truth docs and vendor documentation. Out-of-bundle links appear ONLY in
+this section. External web URLs are permitted here and nowhere else.}}
+
+- [{{Doc Title}}]({{PATH}}) — {{what it authoritatively covers}}

--- a/knowledge-vault/templates/starter-bundle/_meta/templates/pattern.md
+++ b/knowledge-vault/templates/starter-bundle/_meta/templates/pattern.md
@@ -1,0 +1,40 @@
+---
+type: pattern
+title: "{{Title}}"
+description: "{{ONE_SENTENCE ≤160 chars: the reusable approach and the problem it solves}}"
+resource: "{{PATH}}"
+tags: [{{TAGS}}, ssot-stub]
+timestamp: {{YYYY-MM-DD}}
+status: active
+domain: {{DOMAIN}}
+docs:
+  - "{{PATH}}"
+verified_against: "{{GIT_SHA}}"
+---
+
+# {{Title}}
+
+**This is a map-card. The full pattern lives in the source-of-truth document cited below — do not
+restate it here.** If you are restating more than a paragraph, stop and link. A stub that
+duplicates its source becomes two things to maintain, and they will diverge.
+
+## Overview
+
+{{3-5 sentences: what the pattern is, when to reach for it, and when NOT to. Enough for a reader
+to decide whether to open the full document — no more.}}
+
+## Exemplars
+
+{{2-5 bullets: real places in the codebase where this pattern is applied correctly, each with one
+clause on what makes it a good example. Name code files as plain inline code; never link to them.
+Code paths belong in `resource` and `sources`.}}
+
+- `{{PATH}}` — {{why this is the reference implementation}}
+
+## Citations
+
+{{1-4 bullets. A stub type MUST carry an out-of-bundle citation to its source of truth — the
+validator enforces this. Out-of-bundle links appear ONLY in this section. Relative markdown links
+only: no wikilinks, no leading-slash paths, no repository-host URLs for files in this repo.}}
+
+- [{{Pattern Document}}]({{PATH}}) — the authoritative definition

--- a/knowledge-vault/templates/starter-bundle/_meta/templates/process.md
+++ b/knowledge-vault/templates/starter-bundle/_meta/templates/process.md
@@ -1,0 +1,43 @@
+---
+type: process
+title: "{{Title}}"
+description: "{{ONE_SENTENCE ≤160 chars: the recurring way of working this concept describes}}"
+tags: [{{TAGS}}]
+timestamp: {{YYYY-MM-DD}}
+status: active
+domain: {{DOMAIN}}
+ticket: [{{TICKET_IDS}}]
+docs:
+  - "{{PATH}}"
+---
+
+# {{Title}}
+
+{{2-4 sentences: the process and the failure it exists to prevent. State the mechanism, not the
+intention — a process defended by a good intention is not a process.}}
+
+## Overview
+
+{{3-5 sentences: when this process runs, what triggers it, and what it produces. If it is
+enforced by tooling, say which tooling; if it is enforced by convention, say so honestly.}}
+
+## Flow
+
+{{4-8 bullets: the ordered steps, each led by a bolded verb phrase and followed by one or two
+sentences of what it means in practice. Include the gate that stops bad work from proceeding.}}
+
+- **{{Step name}}.** {{what happens and what it checks}}
+
+## Roles Involved
+
+{{2-5 bullets: each role by function (never by personal name) and what it is accountable for at
+which step. Accountability, not participation.}}
+
+- **{{Role}}** — {{what they own in this process}}
+
+## Citations
+
+{{1-5 bullets: the authoritative procedure documents and related guides. Out-of-bundle links
+appear ONLY in this section. Relative markdown links only.}}
+
+- [{{Doc Title}}]({{PATH}}) — {{what it authoritatively covers}}

--- a/knowledge-vault/templates/starter-bundle/_meta/templates/runbook.md
+++ b/knowledge-vault/templates/starter-bundle/_meta/templates/runbook.md
@@ -1,0 +1,42 @@
+---
+type: runbook
+title: "{{Title}}"
+description: "{{ONE_SENTENCE ≤160 chars: the operational situation this runbook covers}}"
+tags: [{{TAGS}}]
+timestamp: {{YYYY-MM-DD}}
+status: active
+domain: {{DOMAIN}}
+docs:
+  - "{{PATH}}"
+verified_against: "{{GIT_SHA}}"
+---
+
+# {{Title}}
+
+{{2-4 sentences: the situation, its blast radius, and how urgent it is. Someone reading this at
+3am should know within ten seconds whether they are in the right document.}}
+
+## Overview
+
+{{3-5 sentences: what goes wrong, why, and what a good outcome looks like. Name the signals that
+indicate you are in this scenario.}}
+
+## When To Use
+
+{{3-6 bullets: the concrete triggers — alerts, symptoms, error signatures — plus at least one
+"do NOT use this when" clause pointing to the correct alternative.}}
+
+## Procedure Map
+
+{{4-8 bullets: the ordered phases of the response, each one clause. This is a MAP, not the full
+procedure: if the step-by-step commands live in an operational document, summarize the phases here
+and cite that document. If you are restating more than a paragraph, stop and link.}}
+
+- {{Phase 1 — one clause on what it accomplishes}}
+
+## Citations
+
+{{1-5 bullets: the authoritative procedure document, dashboards, and escalation contacts by role
+(never by personal name). Out-of-bundle links appear ONLY in this section.}}
+
+- [{{Doc Title}}]({{PATH}}) — {{the full step-by-step procedure}}

--- a/knowledge-vault/templates/starter-bundle/_meta/templates/skill.md
+++ b/knowledge-vault/templates/starter-bundle/_meta/templates/skill.md
@@ -1,0 +1,45 @@
+---
+type: skill
+title: "{{Title}}"
+description: "{{ONE_SENTENCE ≤160 chars: the capability this skill provides and when it fires}}"
+resource: "{{PATH}}"
+tags: [agents, {{TAGS}}, ssot-stub]
+timestamp: {{YYYY-MM-DD}}
+status: active
+domain: {{DOMAIN}}
+docs:
+  - "{{PATH}}"
+---
+
+# {{Title}}
+
+**This is a map-card. The skill's procedure lives in the skill definition cited below — do not
+restate its steps here.** The card makes the skill discoverable from the graph; the definition is
+what actually runs.
+
+## Overview
+
+{{3-5 sentences: what the skill does, its invocation trigger, and its output. State any
+precondition that must hold before it is safe to run.}}
+
+## Routes To
+
+{{2-6 bullets: what this skill delegates to or produces — sub-skills, scripts, or the artifacts it
+writes. Name scripts and code files as plain inline code; never link to code files.}}
+
+- `{{PATH}}` — {{what it does in this flow}}
+
+## Used By Roles
+
+{{2-5 bullets: the agent roles that invoke this skill and at which point in their work. Link only
+to concept IDs listed in manifest.json; if a role concept does not exist yet, name it in prose
+without a link and report it as a suggestion.}}
+
+- {{[Role Title](../path/to/role.md) — when and why it invokes this}}
+
+## Citations
+
+{{1-4 bullets. A stub type MUST carry an out-of-bundle citation to its source of truth — the
+validator enforces this. Out-of-bundle links appear ONLY in this section.}}
+
+- [{{Skill Definition}}]({{PATH}}) — the authoritative procedure

--- a/knowledge-vault/templates/starter-bundle/_meta/templates/sop.md
+++ b/knowledge-vault/templates/starter-bundle/_meta/templates/sop.md
@@ -1,0 +1,43 @@
+---
+type: sop
+title: "{{Title}}"
+description: "{{ONE_SENTENCE ≤160 chars: the standard operating procedure and what it governs}}"
+resource: "{{PATH}}"
+tags: [{{TAGS}}, ssot-stub]
+timestamp: {{YYYY-MM-DD}}
+status: active
+domain: {{DOMAIN}}
+docs:
+  - "{{PATH}}"
+---
+
+# {{Title}}
+
+**This is a map-card. The procedure itself lives in the source-of-truth document cited below — do
+not copy the steps here.** Copied steps drift from the original, and the copy is always the one
+someone follows.
+
+## Overview
+
+{{3-5 sentences: what the SOP governs, why it is mandatory rather than advisory, and what has gone
+wrong when it was skipped. Name the enforcement mechanism if one exists.}}
+
+## When It Applies
+
+{{3-6 bullets: the concrete triggers that put you under this SOP, plus at least one boundary case
+clarifying when it does NOT apply. Ambiguity about scope is how an SOP gets ignored.}}
+
+## Affected Concepts
+
+{{2-6 bullets: the concepts and artifact classes governed by this SOP, each with a clause on the
+obligation it creates. Link only to concept IDs listed in manifest.json; name missing ones in
+prose without a link.}}
+
+- {{[Concept Title](../path/to/concept.md) — the obligation this SOP imposes}}
+
+## Citations
+
+{{1-4 bullets. A stub type MUST carry an out-of-bundle citation to its source of truth — the
+validator enforces this. Out-of-bundle links appear ONLY in this section.}}
+
+- [{{SOP Document}}]({{PATH}}) — the authoritative procedure

--- a/knowledge-vault/templates/starter-bundle/_meta/vault-config.json
+++ b/knowledge-vault/templates/starter-bundle/_meta/vault-config.json
@@ -1,0 +1,150 @@
+{
+  "okf_version": "0.1",
+  "bundle_root": "knowledge-vault/templates/starter-bundle",
+  "obsidian_vault_root": "knowledge-vault/templates",
+
+  "_readme": [
+    "This is the machine-readable constitution. CONVENTIONS.md is its human-readable twin;",
+    "keep them in sync. validate-vault.mjs enforces this file.",
+    "",
+    "TO ADAPT THIS TO YOUR PROJECT:",
+    "  1. bundle_root      -> where your vault lives, repo-root-relative",
+    "  2. obsidian_vault_root -> the PARENT of your bundle, so SSoT citations stay clickable",
+    "  3. domains          -> your business domains (empty array disables the check)",
+    "  4. tags             -> your controlled vocabulary (empty array disables the check)",
+    "  5. types            -> add artifact types for your stack (see docs/GUIDE.md)",
+    "",
+    "The 12 types shipped here are stack-agnostic. Types like api-endpoint, database-table,",
+    "or page-route are stack-specific and are yours to define — GUIDE.md shows worked examples."
+  ],
+
+  "domains": ["core", "platform", "product"],
+
+  "statuses": ["active", "deprecated", "experimental", "planned"],
+
+  "max_concept_lines": 60,
+
+  "frontmatter": {
+    "required": ["type", "title", "description", "tags", "timestamp", "status"],
+    "optional": [
+      "resource",
+      "domain",
+      "ticket",
+      "sources",
+      "docs",
+      "verified_against",
+      "okf_version"
+    ],
+    "max_description_length": 160,
+    "path_fields": ["resource", "sources", "docs"]
+  },
+
+  "link_rules": {
+    "style": "relative-markdown",
+    "concept_links_stay_in_bundle": true,
+    "external_repo_links_only_under": "Citations",
+    "forbidden": ["wikilinks", "leading-slash-paths", "github-urls-for-repo-files"]
+  },
+
+  "tags": [
+    "core",
+    "platform",
+    "product",
+
+    "security",
+    "auth",
+    "data",
+    "api",
+    "ui",
+    "testing",
+    "ci",
+    "deployment",
+    "observability",
+    "performance",
+    "content",
+
+    "process",
+    "agents",
+    "onboarding",
+    "ssot-stub",
+    "okf"
+  ],
+
+  "types": {
+    "domain": {
+      "sections": ["Overview", "Members", "Key Flows", "Citations"],
+      "resource_required": false
+    },
+    "architecture": {
+      "sections": ["Overview", "Design", "Related Concepts", "Citations"],
+      "resource_required": false
+    },
+    "integration": {
+      "sections": [
+        "Overview",
+        "Touchpoints",
+        "Configuration",
+        "Failure Modes & Health",
+        "Citations"
+      ],
+      "resource_required": false
+    },
+    "environment": {
+      "sections": ["Overview", "Topology", "Access & Deployment", "Citations"],
+      "resource_required": false
+    },
+    "runbook": {
+      "sections": ["Overview", "When To Use", "Procedure Map", "Citations"],
+      "resource_required": false
+    },
+    "process": {
+      "sections": ["Overview", "Flow", "Roles Involved", "Citations"],
+      "resource_required": false
+    },
+    "pattern": {
+      "sections": ["Overview", "Exemplars", "Citations"],
+      "resource_required": true,
+      "stub": true
+    },
+    "adr": {
+      "sections": ["Overview", "Decision", "Affected Concepts", "Citations"],
+      "resource_required": true,
+      "stub": true
+    },
+    "sop": {
+      "sections": ["Overview", "When It Applies", "Affected Concepts", "Citations"],
+      "resource_required": true,
+      "stub": true
+    },
+    "agent-role": {
+      "sections": [
+        "Overview",
+        "Responsibilities",
+        "Skills & SOPs",
+        "Handoffs",
+        "Citations"
+      ],
+      "resource_required": true,
+      "stub": true
+    },
+    "skill": {
+      "sections": ["Overview", "Routes To", "Used By Roles", "Citations"],
+      "resource_required": true,
+      "stub": true
+    },
+    "guide": {
+      "sections": [],
+      "resource_required": false
+    },
+    "meta": {
+      "sections": [],
+      "resource_required": false,
+      "internal": true
+    },
+    "template": {
+      "sections": [],
+      "resource_required": false,
+      "internal": true
+    }
+  }
+}

--- a/knowledge-vault/templates/starter-bundle/bases/by-domain.base
+++ b/knowledge-vault/templates/starter-bundle/bases/by-domain.base
@@ -1,0 +1,14 @@
+filters:
+  and:
+    - file.inFolder("starter-bundle")
+    - domain != null
+views:
+  - type: table
+    name: Concepts by Domain
+    group_by: domain
+    order:
+      - title
+      - type
+      - tags
+      - status
+      - timestamp

--- a/knowledge-vault/templates/starter-bundle/bases/coverage.base
+++ b/knowledge-vault/templates/starter-bundle/bases/coverage.base
@@ -1,0 +1,22 @@
+filters:
+  and:
+    - file.inFolder("starter-bundle")
+    - type != null
+views:
+  - type: table
+    name: Coverage by Type
+    group_by: type
+    order:
+      - title
+      - domain
+      - status
+      - verified_against
+  - type: table
+    name: Missing a Verification SHA
+    filters:
+      and:
+        - verified_against == null
+    order:
+      - title
+      - type
+      - timestamp

--- a/knowledge-vault/templates/starter-bundle/bases/stale-concepts.base
+++ b/knowledge-vault/templates/starter-bundle/bases/stale-concepts.base
@@ -1,0 +1,27 @@
+filters:
+  and:
+    - file.inFolder("starter-bundle")
+    - type != null
+views:
+  - type: table
+    name: Staleness Radar (oldest first)
+    order:
+      - title
+      - type
+      - timestamp
+      - verified_against
+      - domain
+    sort:
+      - property: timestamp
+        direction: ASC
+  - type: table
+    name: Needs Attention (deprecated or planned)
+    filters:
+      or:
+        - status == "deprecated"
+        - status == "planned"
+    order:
+      - title
+      - type
+      - status
+      - timestamp

--- a/knowledge-vault/templates/starter-bundle/bases/ticket-index.base
+++ b/knowledge-vault/templates/starter-bundle/bases/ticket-index.base
@@ -1,0 +1,16 @@
+filters:
+  and:
+    - file.inFolder("starter-bundle")
+    - ticket != null
+views:
+  - type: table
+    name: Concepts by Ticket
+    order:
+      - title
+      - type
+      - ticket
+      - domain
+      - timestamp
+    sort:
+      - property: ticket
+        direction: DESC

--- a/knowledge-vault/templates/starter-bundle/index.md
+++ b/knowledge-vault/templates/starter-bundle/index.md
@@ -1,0 +1,58 @@
+---
+type: meta
+title: "Knowledge Vault"
+description: "Root index for this OKF knowledge bundle: the map of the system and the institutional knowledge around it."
+tags: [okf]
+timestamp: 2026-07-19
+okf_version: "0.1"
+---
+
+# Knowledge Vault
+
+This vault is a **map, not the territory**. Single-source-of-truth documents stay where they
+live; the code stays authoritative over everything, including this vault. Concepts here are
+short map-cards that summarize and link — they never restate their sources.
+
+> **This is the starter bundle.** It validates clean as shipped. Replace this content with your
+> own, keep the structure, and delete this callout.
+
+## Start Here
+
+- [Start Here](start-here.md) — the ordered onboarding path, where every step says why it comes there
+
+## Sections
+
+Create one directory per section, each with its own `index.md`. Suggested starting set — keep what
+fits your system, delete what does not:
+
+- **Architecture** — cross-cutting views that have no single underlying file
+- **Domains** — business-domain hubs that re-group artifacts by what they are *for*
+- **Integrations** — third-party services and what they touch
+- **Operations** — environments, CI, runbooks
+- **Knowledge** — patterns, ADRs, SOPs, agent roles, skills, process
+
+## Process
+
+- [Vault Maintenance](process/vault-maintenance.md) — how this vault stays honest as the code moves
+
+## Maps
+
+Obsidian canvases live under `maps/`. See the Obsidian guide for the layout conventions.
+
+## Views
+
+Obsidian Bases live under `bases/`. `stale-concepts.base` is the maintenance queue — it sorts
+concepts by how long it has been since anyone verified them against source.
+
+## Conventions
+
+Every concept is one file with an exact frontmatter contract and a fixed section list for its
+type. Links are relative markdown only; concept-to-concept links never leave this bundle, and
+links that do leave appear only under `## Citations`. Link only to IDs that exist in
+`_meta/manifest.json` — never invent a link. The rules live in
+[CONVENTIONS.md](_meta/CONVENTIONS.md); the machine-readable form is `_meta/vault-config.json`,
+enforced by the validator.
+
+## Log
+
+- [Log](log.md) — dated changelog, newest first

--- a/knowledge-vault/templates/starter-bundle/log.md
+++ b/knowledge-vault/templates/starter-bundle/log.md
@@ -1,0 +1,18 @@
+# Log
+
+Newest first. Every pull request that touches the vault prepends an entry here.
+
+An entry records **what changed, why (ticket reference), and the source SHA** the claims were
+verified against. Deprecation is a log entry plus `status: deprecated` — never a silent deletion.
+
+Remember: **a citation is not re-verification.** Only re-deriving a concept from its sources
+bumps that concept's `timestamp` and `verified_against`.
+
+## 2026-07-19
+
+Starter bundle created. Replace this entry with your own first build.
+
+An initial build entry should record the shape of what was mapped and how it was verified, for
+example: *"N concepts across &lt;areas&gt;. Sources verified against commit `abc1234`. Built by a
+multi-agent pipeline: E extraction agents, G generation agents, and V adversarial verifiers whose
+F evidence-backed findings were all corrected; gated by the validator and markdownlint."*

--- a/knowledge-vault/templates/starter-bundle/maps/system-overview.canvas
+++ b/knowledge-vault/templates/starter-bundle/maps/system-overview.canvas
@@ -1,0 +1,22 @@
+{
+	"nodes":[
+		{"id":"lbl-entry","type":"text","text":"## Entry\n\nWhere requests or users arrive","x":-80,"y":-360,"width":320,"height":100},
+		{"id":"lbl-logic","type":"text","text":"## Logic\n\nHandlers, services, jobs","x":420,"y":-360,"width":320,"height":100},
+		{"id":"lbl-data","type":"text","text":"## Data\n\nStores and schemas","x":920,"y":-360,"width":320,"height":100},
+		{"id":"lbl-external","type":"text","text":"## External\n\nThird-party services","x":420,"y":420,"width":320,"height":100},
+
+		{"id":"n-entry","type":"text","text":"Replace with a `file` node pointing at your entry-point concept, e.g.\n\n`starter-bundle/architecture/request-lifecycle.md`","x":-80,"y":-200,"width":320,"height":180},
+		{"id":"n-logic","type":"text","text":"Replace with your handler or service concepts. One node per load-bearing concept — not every file.","x":420,"y":-200,"width":320,"height":180},
+		{"id":"n-data","type":"text","text":"Replace with your datastore concepts.","x":920,"y":-200,"width":320,"height":180},
+
+		{"id":"n-process","type":"file","file":"starter-bundle/process/vault-maintenance.md","x":420,"y":60,"width":400,"height":300},
+		{"id":"n-start","type":"file","file":"starter-bundle/start-here.md","x":-80,"y":60,"width":400,"height":300},
+
+		{"id":"note","type":"text","text":"**Architectural canvas.** Labelled columns at a fixed pitch (500px here), one card per load-bearing concept, edges showing real dependency or data flow.\n\nCanvas nodes are `file` references into real concepts — clicking one opens the note. This is a spatial layout over the vault, not a separate diagram to maintain.","x":920,"y":60,"width":400,"height":300}
+	],
+	"edges":[
+		{"id":"e1","fromNode":"n-entry","fromSide":"right","toNode":"n-logic","toSide":"left","label":"every request"},
+		{"id":"e2","fromNode":"n-logic","fromSide":"right","toNode":"n-data","toSide":"left","label":"reads / writes"},
+		{"id":"e3","fromNode":"n-start","fromSide":"right","toNode":"n-process","toSide":"left","label":"then maintain it"}
+	]
+}

--- a/knowledge-vault/templates/starter-bundle/maps/vault-lifecycle.canvas
+++ b/knowledge-vault/templates/starter-bundle/maps/vault-lifecycle.canvas
@@ -1,0 +1,21 @@
+{
+	"nodes":[
+		{"id":"build","type":"text","text":"## 1. Build\n\nExtract → Generate → Navigate → **Adversarially verify**\n\nEvery concept stamped with `verified_against`","x":0,"y":0,"width":380,"height":220},
+		{"id":"drift","type":"text","text":"## 2. Code moves\n\nA merge changes a file some concept claims to describe.\n\nThe vault is now quietly wrong.","x":480,"y":0,"width":380,"height":220},
+		{"id":"detect","type":"text","text":"## 3. Detect\n\n`git diff baseline_sha..HEAD` over the watch-list.\n\nStale **iff** a changed path matches `resource` or `sources`.","x":960,"y":0,"width":380,"height":220},
+		{"id":"regen","type":"text","text":"## 4. Regenerate\n\nOnly what drifted. Re-derive from source — never patch prose without re-reading the code.","x":960,"y":300,"width":380,"height":220},
+		{"id":"gate","type":"text","text":"## 5. Gate\n\nValidator exits 0, lint passes, log entry prepended, `baseline_sha` bumped.","x":480,"y":300,"width":380,"height":220},
+
+		{"id":"n-maint","type":"file","file":"starter-bundle/process/vault-maintenance.md","x":0,"y":300,"width":380,"height":220},
+
+		{"id":"note","type":"text","text":"**Flow canvas.** Edge-dense, one node per step, tracing a single loop end to end.\n\nThe loop is what makes the vault trustworthy: staleness is computed, not felt.","x":480,"y":600,"width":380,"height":180}
+	],
+	"edges":[
+		{"id":"f1","fromNode":"build","fromSide":"right","toNode":"drift","toSide":"left"},
+		{"id":"f2","fromNode":"drift","fromSide":"right","toNode":"detect","toSide":"left"},
+		{"id":"f3","fromNode":"detect","fromSide":"bottom","toNode":"regen","toSide":"top"},
+		{"id":"f4","fromNode":"regen","fromSide":"left","toNode":"gate","toSide":"right"},
+		{"id":"f5","fromNode":"gate","fromSide":"left","toNode":"n-maint","toSide":"right"},
+		{"id":"f6","fromNode":"n-maint","fromSide":"top","toNode":"build","toSide":"bottom","label":"loop"}
+	]
+}

--- a/knowledge-vault/templates/starter-bundle/process/vault-maintenance.md
+++ b/knowledge-vault/templates/starter-bundle/process/vault-maintenance.md
@@ -1,0 +1,46 @@
+---
+type: process
+title: "Vault Maintenance"
+description: "How this vault stays honest as the code moves: drift detection, targeted regeneration, and the record."
+tags: [process, okf]
+timestamp: 2026-07-19
+status: active
+domain: platform
+---
+
+# Vault Maintenance
+
+## Overview
+
+A knowledge base that is not maintained becomes confidently wrong, which is worse than absent.
+This vault defends against that with a mechanism rather than a good intention: every concept
+records the commit its claims were checked against, so staleness is a fact you can compute
+instead of a feeling.
+
+## Flow
+
+- **Detect drift.** Read `baseline_sha` from `_meta/manifest.json` and diff it to HEAD across the
+  watch-list of source paths. A concept is stale if and only if a changed path matches its
+  `resource` or one of its `sources` — file-level truth, not a time-based guess.
+- **Detect inventory change.** Re-enumerate the source globs and compare against the manifest.
+  A new source with no concept gets one (manifest entry first). A deleted source gets
+  `status: deprecated` — never a silent file deletion, because inbound links must be cleaned first.
+- **Regenerate only what drifted.** Re-derive facts from the source files. Never patch prose
+  without re-reading the code it describes.
+- **Validate.** The validator exits 0 and markdown lint passes, or the change does not ship.
+- **Record.** Prepend a dated entry to the log, then bump `baseline_sha` and `generated`.
+
+## Roles Involved
+
+- **Whoever merged the change** — responsible for noticing that a merge moved the territory.
+- **The maintenance agent or author** — runs the sync and re-derives the affected concepts.
+- **Reviewer** — confirms the claims were re-verified, not merely re-worded.
+
+## Citations
+
+- [Conventions](../_meta/CONVENTIONS.md) — the rules this process enforces
+
+The full method lives in the harness at `knowledge-vault/docs/GUIDE.md`, and the first-build steps
+at `knowledge-vault/docs/ADOPTION-PLAYBOOK.md`. Those are named rather than linked on purpose: this
+bundle is meant to be **copied** to wherever your vault will live, and a relative link out of the
+bundle would break the moment you move it. Cite paths that travel with the bundle; name the rest.

--- a/knowledge-vault/templates/starter-bundle/start-here.md
+++ b/knowledge-vault/templates/starter-bundle/start-here.md
@@ -1,0 +1,70 @@
+---
+type: guide
+title: "Start Here"
+description: "The ordered path through this vault for someone new to the system, where each step explains why it comes where it does."
+tags: [onboarding]
+timestamp: 2026-07-19
+status: active
+---
+
+# Start Here
+
+New to this system? Read the vault in this order. **Each step names why it comes where it does** —
+that ordering is the teaching, not decoration. Do not skip ahead of the step that establishes the
+one convention you cannot violate.
+
+> **Starter bundle.** The steps below are the *shape* to fill in. Replace each with a real link
+> into your vault and a real WHY. Delete this callout when you do.
+
+## 1. The stack
+
+What this system is built from, and the current versions.
+
+**WHY first:** every concept after this assumes you can read the vocabulary.
+
+## 2. The system on one surface
+
+The overview concept, with the system-overview canvas open beside it.
+
+**WHY here:** a shape you can point at makes every later detail land somewhere.
+
+## 3. The non-negotiable convention
+
+The security or correctness rule that everything else assumes — the one thing that, violated once,
+causes real damage.
+
+**WHY now:** this is the convention you cannot break even once, so it comes before you read any
+code-shaped concept.
+
+## 4. One traced vertical slice
+
+Pick a single real flow and follow it end to end — entry point, to the handler, to the store it
+writes.
+
+**WHY:** one traced flow teaches the conventions that every other flow in the system repeats.
+Breadth after depth, never before.
+
+## 5. The patterns
+
+The pattern library, now that you have seen one real instance of it.
+
+**WHY here:** having seen one real flow, the patterns read as generalizations instead of
+abstractions.
+
+## 6. How work moves
+
+The workflow, the roles, and the gates.
+
+**WHY before touching code:** the pipeline rejects non-conforming branches and commits, so
+learning this late costs you a force-push.
+
+## 7. Local setup
+
+Getting it running on your machine.
+
+**WHY last:** setup goes fastest once you already know what each piece is for.
+
+## Where to ask
+
+Point at your contribution guide and your team's channel. As a `guide` type, this file may link
+outside the bundle anywhere — that exemption exists precisely so onboarding can hand off.

--- a/knowledge-vault/tests/test-validator-gates.sh
+++ b/knowledge-vault/tests/test-validator-gates.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# test-validator-gates.sh — prove the vault validator's gates actually enforce.
+#
+# A gate that only ever passes is not a gate. Each case below deliberately breaks one rule
+# and asserts the validator reports it. The final case asserts the shipped starter bundle
+# is clean, and that it survives being copied (the flow the quickstart tells adopters to run).
+#
+# Usage: bash knowledge-vault/tests/test-validator-gates.sh
+# Exit:  0 all assertions passed, 1 otherwise
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+VALIDATOR="$ROOT/knowledge-vault/scripts/validate-vault.mjs"
+BUNDLE="$ROOT/knowledge-vault/templates/starter-bundle"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; DIM='\033[0;36m'; NC='\033[0m'
+pass=0; fail=0
+
+reset_fixture() {
+  rm -rf "$WORK/vault"
+  cp -r "$BUNDLE" "$WORK/vault"
+}
+
+# assert_error <pattern> <description>
+assert_error() {
+  local pattern="$1" desc="$2" out
+  out="$(node "$VALIDATOR" --vault "$WORK/vault" 2>&1)"
+  if grep -q "$pattern" <<<"$out"; then
+    echo -e "  ${GREEN}PASS${NC} $desc"
+    pass=$((pass + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} $desc — expected an error matching: $pattern"
+    echo "$out" | sed 's/^/        /'
+    fail=$((fail + 1))
+  fi
+}
+
+# assert_clean <dir> <description>
+assert_clean() {
+  local dir="$1" desc="$2" out
+  if out="$(node "$VALIDATOR" --vault "$dir" 2>&1)"; then
+    echo -e "  ${GREEN}PASS${NC} $desc"
+    pass=$((pass + 1))
+  else
+    echo -e "  ${RED}FAIL${NC} $desc — expected exit 0"
+    echo "$out" | sed 's/^/        /'
+    fail=$((fail + 1))
+  fi
+}
+
+echo -e "${DIM}--- The shipped bundle is clean ---${NC}"
+assert_clean "$BUNDLE" "starter bundle validates with zero errors"
+
+echo -e "${DIM}--- Gate: wikilinks are rejected ---${NC}"
+reset_fixture
+printf '\n[[some-concept]]\n' >>"$WORK/vault/process/vault-maintenance.md"
+assert_error "wikilink" "a wikilink is an error"
+
+echo -e "${DIM}--- Gate: repo-host URLs for repo files are rejected ---${NC}"
+reset_fixture
+python3 - "$WORK/vault/process/vault-maintenance.md" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read().replace(
+    "## Citations",
+    "## Citations\n\n- [x](https://github.com/org/repo/blob/main/x.ts) — repo file by URL", 1)
+open(p, "w").write(s)
+PY
+assert_error "repo-host URL" "a repo-host URL to a repo file is an error"
+
+echo -e "${DIM}--- Gate: frontmatter paths must exist ---${NC}"
+reset_fixture
+python3 - "$WORK/vault/process/vault-maintenance.md" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read().replace("domain: platform", 'domain: platform\nresource: "does/not/exist.ts"')
+open(p, "w").write(s)
+PY
+assert_error "path does not exist" "a resource pointing at a missing file is an error"
+
+echo -e "${DIM}--- Gate: stub types must cite their source of truth ---${NC}"
+reset_fixture
+cat >"$WORK/vault/orphan-pattern.md" <<'MD'
+---
+type: pattern
+title: "Example Pattern"
+description: "A stub concept that fails to cite any source of truth."
+resource: "knowledge-vault/README.md"
+tags: [process]
+timestamp: 2026-07-19
+status: active
+---
+
+# Example Pattern
+
+## Overview
+
+Body.
+
+## Exemplars
+
+None.
+
+## Citations
+
+- [Conventions](_meta/CONVENTIONS.md)
+MD
+assert_error "is a stub" "a stub type with no out-of-bundle citation is an error"
+
+echo -e "${DIM}--- Gate: canvas nodes must reference real files ---${NC}"
+reset_fixture
+python3 - "$WORK/vault/maps/system-overview.canvas" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read().replace("starter-bundle/start-here.md", "starter-bundle/ghost.md")
+open(p, "w").write(s)
+PY
+assert_error "canvas node references missing" "a dangling canvas node is an error"
+
+echo -e "${DIM}--- Gate: every concept must be in the manifest registry ---${NC}"
+reset_fixture
+python3 - "$WORK/vault/_meta/manifest.json" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read().replace('"id": "start-here",', '"id": "start-here-renamed",')
+open(p, "w").write(s)
+PY
+assert_error "not in manifest" "a concept missing from the ID registry is an error"
+
+echo -e "${DIM}--- Gate: section structure must match the type template ---${NC}"
+reset_fixture
+python3 - "$WORK/vault/process/vault-maintenance.md" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read().replace("## Roles Involved", "## Who Does It")
+open(p, "w").write(s)
+PY
+assert_error "!= template" "a renamed section is an error"
+
+echo -e "${DIM}--- The bundle survives being copied (quickstart flow) ---${NC}"
+rm -rf "$WORK/moved"
+cp -r "$BUNDLE" "$WORK/moved"
+sed -i.bak 's|"starter-bundle/|"moved/|g' "$WORK/moved"/maps/*.canvas && rm -f "$WORK/moved"/maps/*.bak
+python3 - "$WORK/moved/_meta/vault-config.json" "$WORK/moved" <<'PY'
+import sys
+p, newroot = sys.argv[1], sys.argv[2]
+s = open(p).read().replace(
+    '"bundle_root": "knowledge-vault/templates/starter-bundle"',
+    '"bundle_root": "%s"' % newroot)
+open(p, "w").write(s)
+PY
+assert_clean "$WORK/moved" "copied bundle validates clean after the documented rewrite"
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo -e "${GREEN}All $pass assertions passed.${NC}"
+  exit 0
+fi
+echo -e "${RED}$fail failed, $pass passed.${NC}"
+exit 1


### PR DESCRIPTION
# Pull Request: OKF knowledge-vault subsystem [SAW-45]

## 📋 Summary

**Linear**: [SAW-45](https://linear.app/cheddarfox/issue/SAW-45) (epic) · SAW-46 … SAW-52

> ⚠️ **Stacked on #53.** Base is `SAW-39-safe-ai-dlc-methodology-layer`, not `dev` — both PRs touch the skill indexes and counts. **Retarget to `dev` once #53 merges.**

The harness has **zero** knowledge-base tooling. Verified against `dev` @ v2.10.0: no hits for vault, OKF, Obsidian, or knowledge-graph anywhere.

That is a strange gap for a harness whose job is multi-agent onboarding. Downstream, an independent architecture audit of the originating project scored its vault **"the single strongest KT asset in the repo"** — the *only* positive finding in a NEEDS WORK documentation dimension — and told new developers to trust it **over** that project's own canonical context file, because the vault's claims were verified against a SHA and the canonical file's had silently drifted.

Not that a vault is tidy. That it is **checkable**.

## 🎯 Changes Made

[Open Knowledge Format v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) (Google, Apache-2.0) is the substrate — it requires only `type` and keeps conformance deliberately loose. **This contributes the rigor layer on top:**

- **`verified_against` + `baseline_sha`** — staleness is a `git diff` over a watch-list, not a guess from age. Plus the discipline that keeps it honest: *a citation is not re-verification*.
- **The anti-hallucination link rule** — agents may link only to IDs in the manifest registry. This is what lets dozens of parallel authoring agents produce a coherent graph instead of confident broken references.
- **The four-part generation prompt** — template + golden example + hard rules + ID registry.
- Stub-don't-duplicate · code-wins-over-docs · the three-axis taxonomy · two-door navigation.

**Shipped** as an opt-in subsystem mirroring `dark-factory/`: zero-dependency validator (`node:` builtins only — runs without a `package.json`), a starter bundle that validates clean, 12 stack-agnostic type templates, the Obsidian layer (Bases, canvases, and the three settings without which the GUI emits wikilinks that fail validation), `vault-sync` at four-provider parity, `04-knowledge-vault.mdc`, and an opt-in CI workflow template.

**Two build prompts** — the generic `BUILD-PROMPT.md` for adopters, and `SAW-VAULT-BUILD.md` **pre-scoped to this repo and runnable as-is**, with a ready-to-file epic. SAW is a harness repo, not a web app, so its vault uses almost entirely the stack-agnostic types kept and almost none of the web-shaped ones stripped — the best available proof the genericization holds. Both are one click from `README.md`.

**Defects fixed during the port, not carried forward:** the validator now reads `bundle_root` from config instead of hardcoding a path; detects wikilinks and repo-host URLs (previously *declared forbidden but undetected*); verifies `resource`/`sources`/`docs` exist; validates canvas node references; enforces the stub contract.

## 🧪 Testing

**`knowledge-vault/tests/test-validator-gates.sh` — 9/9.** Each assertion deliberately breaks a rule and asserts the validator *fails*. A gate that only ever passes is the exact defect this subsystem exists to prevent, so it is proven rather than claimed.

**Independent QAS** ran the full acceptance criteria and returned **FAIL first**, then PASS after fixes:

- **4 MAJOR** — all count/attribution errors in `SAW-VAULT-BUILD.md`, the one file whose purpose is count accuracy. Sharpest: the doc claimed *"Enumerated against commit `f03e213`"* while quoting branch-tip values. In a document arguing counts must be tied to a SHA, a wrong SHA is the load-bearing error. Now defers to Appendix A as authoritative.
- **QAS also caught its own harness invalidating all 20 of its violation tests**, rebuilt with a control, and re-ran — unprompted.
- **2 further MINORs**, including that my *fix for overclaiming was itself overclaiming*: `CONVENTIONS.md` said markdownlint enforced fenced-block languages and table pipes; empirically MD040 was `false` and MD055 defaulted to `consistent`. Rules are now genuinely enabled (vault lints clean under all three), and the config ships **inside** the bundle so it travels with adopters.

**Verified**: 20 documented rules confirmed enforced · quickstart replayed verbatim in a fresh repo (4/4 steps, no stray files) · 12/12 templates match config sections exactly · zero leaked identifiers in added lines · attribution blocks byte-identical · zero broken links · zero lint regressions, all 20 vault files 0-error under stricter rules.

**Known-limitation disclosure — not claimed as covered:**

1. `vault-sync` drift detection is reviewed as prose only, never executed end-to-end — it needs a built vault, which `SAW-VAULT-BUILD.md` produces.
2. Obsidian Bases/canvas *rendering* is unverified; only that canvas node paths resolve on disk and `.base` files are well-formed.

`tests/test-fork-sync.sh` fails identically on clean `dev` (missing fixture) — pre-existing, unrelated.

## 📊 Impact Analysis

63 files, +5000/−19. **No breaking changes** — purely additive plus index/count updates. The subsystem is opt-in; nothing in the harness depends on it. Skills 19 → 20, cursor rules 17 → 18, all verified by enumeration.

## 🔄 Multi-Team Coordination

Rebase-first, linear history, merge via **"Rebase and merge"**. **Retarget to `dev` after #53 merges.**

Consider adding `knowledge-vault/` to `sync_scope` (as `dark-factory/` already is) so downstream forks receive it.

## ✅ Pre-merge Checklist

- [x] Validator gates proven to fail when broken (9 assertions + 20 QAS violations)
- [x] Starter bundle validates clean, in place and after the documented copy
- [x] Independent QAS: **PASS**
- [x] Fully genericized; placeholders match the manifest `identity:` block
- [x] Every new `README.md` carries the License + IP block
- [x] Version-frozen docs untouched
- [ ] Retarget to `dev` after #53
- [ ] HITL merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
