### PR TITLE
fix(sync): make the sync engine and its tests work on BSD/macOS [SAW-61]

### DIFF
--- a/scripts/sync-claude-harness.sh
+++ b/scripts/sync-claude-harness.sh
@@ -126,16 +126,16 @@ get_sync_scope() {
         local in_scope=false
         while IFS= read -r line; do
             # Detect sync_scope: array start
-            if echo "$line" | grep -q '^\s*sync_scope:'; then
+            if echo "$line" | grep -q '^[[:space:]]*sync_scope:'; then
                 in_scope=true
                 continue
             fi
             # Stop at next non-array line (not starting with -)
             if [ "$in_scope" = true ]; then
-                if echo "$line" | grep -q '^\s*-'; then
+                if echo "$line" | grep -q '^[[:space:]]*-'; then
                     # Extract value: strip leading whitespace, dash, quotes, trailing /
                     local domain
-                    domain=$(echo "$line" | sed 's/^\s*-\s*//; s/^["'"'"']//; s/["'"'"']$//; s|/$||; s/\s*$//')
+                    domain=$(echo "$line" | sed 's/^[[:space:]]*-[[:space:]]*//; s/^["'"'"']//; s/["'"'"']$//; s|/$||; s/[[:space:]]*$//')
                     [ -z "$domain" ] && continue
                     # Validate against allowed domains
                     local valid=false
@@ -1493,7 +1493,14 @@ do_rollback() {
         ts_name=$(basename "$ts_dir")
         # Parse ISO timestamp to epoch for comparison
         local epoch
-        epoch=$(date -d "$ts_name" +%s 2>/dev/null || echo 0)
+        # GNU date understands -d; BSD/macOS date needs -j -f with an explicit
+        # input format. Try GNU first, then BSD, and only then give up. Without
+        # the BSD arm every epoch was 0 on macOS, so no backup ever ranked as
+        # latest and do_rollback reported "No backups available" with backups
+        # sitting on disk.
+        epoch=$(date -d "$ts_name" +%s 2>/dev/null \
+            || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$ts_name" +%s 2>/dev/null \
+            || echo 0)
         if [ "$epoch" -gt "$latest_epoch" ]; then
             latest_epoch=$epoch
             latest_timestamp="$ts_name"
@@ -1556,8 +1563,12 @@ do_diff() {
 
     local new=0 modified=0 deleted=0 excluded=0 unchanged=0 renamed=0 protected=0
 
-    # Track directory rename file counts for summary output
-    declare -A dir_rename_counts
+    # Track directory rename file counts for summary output.
+    # Parallel indexed arrays, not an associative array: `declare -A` requires
+    # bash 4, and macOS ships bash 3.2 where it aborts do_diff outright, so no
+    # patches were ever generated on a stock Mac.
+    local dir_rename_keys=()
+    local dir_rename_vals=()
 
     # Determine manifest version for path handling
     local manifest_ver=""
@@ -1637,7 +1648,20 @@ do_diff() {
                 fi
             done < <(get_directory_renames)
             if [ -n "$dir_key" ]; then
-                dir_rename_counts["$dir_key"]=$(( ${dir_rename_counts["$dir_key"]:-0} + 1 ))
+                local dr_i=0 dr_found=-1
+                while [ $dr_i -lt ${#dir_rename_keys[@]} ]; do
+                    if [ "${dir_rename_keys[$dr_i]}" = "$dir_key" ]; then
+                        dr_found=$dr_i
+                        break
+                    fi
+                    dr_i=$((dr_i + 1))
+                done
+                if [ $dr_found -ge 0 ]; then
+                    dir_rename_vals[$dr_found]=$(( ${dir_rename_vals[$dr_found]} + 1 ))
+                else
+                    dir_rename_keys+=("$dir_key")
+                    dir_rename_vals+=(1)
+                fi
             fi
         fi
 
@@ -1697,14 +1721,17 @@ do_diff() {
     done < <(find "$DOMAIN_DIR" -type f ! -path "$BACKUP_DIR/*" -print0 2>/dev/null)
 
     # Show directory rename summary lines for this domain
-    if [ ${#dir_rename_counts[@]} -gt 0 ]; then
+    if [ ${#dir_rename_keys[@]} -gt 0 ]; then
         echo ""
-        for dir_key in "${!dir_rename_counts[@]}"; do
+        local dr_j=0
+        while [ $dr_j -lt ${#dir_rename_keys[@]} ]; do
+            dir_key="${dir_rename_keys[$dr_j]}"
             local src_dir="${dir_key%%|*}"
             local dst_dir="${dir_key##*|}"
-            local count="${dir_rename_counts[$dir_key]}"
+            local count="${dir_rename_vals[$dr_j]}"
             echo -e "${CYAN}RENAMED${NC}  ${src_dir} -> ${dst_dir} ($count files)"
             renamed=$((renamed + count))
+            dr_j=$((dr_j + 1))
         done
     fi
 

--- a/tests/test-multi-domain-sync.sh
+++ b/tests/test-multi-domain-sync.sh
@@ -603,7 +603,7 @@ result=$(
     generate_apply_order "$patches_version_dir" "test-v1" 2>/dev/null
 
     # Verify results
-    patch_count=$(find "$patches_version_dir" -name "*.patch" | wc -l)
+    patch_count=$(find "$patches_version_dir" -name "*.patch" | wc -l | tr -d " ")
     echo "PATCH_COUNT:$patch_count"
 
     if [ -f "$patches_version_dir/APPLY_ORDER.md" ]; then
@@ -617,8 +617,8 @@ result=$(
     fi
 
     # Check patches from first domain weren't wiped by second
-    claude_patches=$(find "$patches_version_dir" -name "*bsa*.patch" | wc -l)
-    gemini_patches=$(find "$patches_version_dir" -name "*skills*.patch" | wc -l)
+    claude_patches=$(find "$patches_version_dir" -name "*bsa*.patch" | wc -l | tr -d " ")
+    gemini_patches=$(find "$patches_version_dir" -name "*skills*.patch" | wc -l | tr -d " ")
     echo "CLAUDE_PATCHES:$claude_patches"
     echo "GEMINI_PATCHES:$gemini_patches"
 

--- a/tests/test-multi-domain-sync.sh
+++ b/tests/test-multi-domain-sync.sh
@@ -65,7 +65,18 @@ assert_not_contains() {
 make_sourceable() {
     local src="$1"
     local dst="$2"
-    sed -n '1,/^case "\${1:-}"/p' "$src" | head -n -3 > "$dst"
+    # Drop the trailing 3 lines of the extracted prefix. `head -n -3` is a GNU
+    # extension; BSD/macOS head rejects a negative count ("illegal line count"),
+    # which under `set -euo pipefail` aborted this entire suite before Test 1.
+    # Count first, then take an explicit positive head so both behave alike.
+    local extracted total
+    extracted=$(sed -n '1,/^case "\${1:-}"/p' "$src")
+    total=$(printf '%s\n' "$extracted" | wc -l | tr -d ' ')
+    if [ "$total" -gt 3 ]; then
+        printf '%s\n' "$extracted" | head -n "$((total - 3))" > "$dst"
+    else
+        : > "$dst"
+    fi
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary

**Linear**: [SAW-61](https://linear.app/cheddarfox/issue/SAW-61) · discovered while verifying SAW-60

The sync engine relied on four GNU-only constructs. On macOS (bash 3.2, BSD coreutils) each failed silently or fatally — and the suite that would have caught them **could not run at all**, so none of it was visible from CI, which runs Ubuntu with GNU coreutils.

Found by refusing to promote SAW-60 on "CI will prove it" and insisting on local verification first.

## The defects

| # | Where | Defect | Consequence on macOS |
| --- | --- | --- | --- |
| 1 | `sync-claude-harness.sh` 129/135/138 | `sync_scope` parsed with GNU-only `\s`; BSD sed ignores it | **Every** domain rejected as unknown → `sync_scope` silently falls back to `.claude` alone |
| 2 | `sync-claude-harness.sh` ~1496 | `do_rollback` used GNU `date -d`, error swallowed by `\|\| echo 0` | Every backup scored epoch 0 → **"No backups available" with backups on disk** |
| 3 | `sync-claude-harness.sh` 1567 | `do_diff` used `declare -A` (bash 4) | Function aborts outright → **no patches ever generated** |
| 4 | `test-multi-domain-sync.sh` | asserted on BSD-padded `wc -l` | `PATCH_COUNT:       2` never matched `PATCH_COUNT:2` |
| 5 | `test-multi-domain-sync.sh` 68 | `head -n -3` (GNU) aborted the suite | **0 of 14 tests ever executed on macOS** — why 1–4 hid |

Defect 1 is the most serious for adopters: a macOS user running multi-domain sync has been receiving `.claude/` updates only — never `.gemini/`, `.codex/`, `.cursor/`, `.agents/` or `dark-factory/`. Warnings go to stderr and the exit code stays clean, so nothing surfaces it.

Defect 2 is the most dangerous: rollback is the safety net for a bad sync, and it was dead.

## Fixes

- `\s` → POSIX `[[:space:]]` (portable to BSD and GNU)
- `date -d` → GNU first, then BSD `date -j -f`, then give up
- `declare -A` → parallel indexed arrays (bash 3.2 compatible)
- `wc -l` output trimmed before comparison
- `head -n -3` → count, then explicit positive head (verified byte-identical to GNU semantics)

## Testing — all local, on the affected platform

macOS, bash 3.2.57, BSD coreutils:

```text
multi-domain-sync:  0 of 14 tests could execute  ->  41/41 PASS, exit 0
full suite sweep:   4 of 9 suites passing        ->  8 of 9 passing

test-manifest-init      PASS (52)   test-preflight        PASS (45)
test-manifest-loader    PASS (24)   test-protected-files  PASS (54)
test-multi-domain-sync  PASS (41)   test-rename-diff      PASS (50)
test-patch-generation   PASS (50)   test-substitutions    PASS (49)
```

Fixes 3 and 4 also repaired `rename-diff` (38→50), `protected-files` (48→54) and `substitutions` (aborting→49), which all route through `do_diff`.

**Not fixed, disclosed:** `test-fork-sync` still fails. Its cause is a **missing fixture** — `tests/fixtures/sync/keryk-ai/.claude/settings.local.json` is absent and `cat` aborts under `set -e`. That is a data gap, not a code defect, it is pre-existing, and it matches the failure reported in GH#53. Tracked separately; I am not claiming it fixed.

## Impact

**No behaviour change on Linux/GNU** — every fix is a portability widening, not a semantic change. On macOS it restores multi-domain sync, rollback, and patch generation, none of which previously worked.

## Checklist

- [x] Rebased on `dev`, linear history
- [x] Verified locally on the affected platform rather than deferred to CI
- [x] Regression-swept all 9 suites
- [x] Remaining failure disclosed with root cause, not glossed
- [ ] HITL merge