### PR TITLE
feat(sync): add knowledge-vault as a Shared sync domain [SAW-60]

### DIFF
--- a/.harness-manifest.schema.json
+++ b/.harness-manifest.schema.json
@@ -214,10 +214,10 @@
       "properties": {
         "sync_scope": {
           "type": "array",
-          "description": "Repo-root-relative directories to sync from upstream. Added in v1.1. Defaults to [\".claude/\"] for v1.0 backward compatibility. Allowed domains: provider (.claude/, .gemini/, .codex/, .cursor/), shared (.agents/, dark-factory/). Release domains (docs/, scripts/, patterns_library/) are not yet supported and will be rejected.",
+          "description": "Repo-root-relative directories to sync from upstream. Added in v1.1. Defaults to [\".claude/\"] for v1.0 backward compatibility. Allowed domains: provider (.claude/, .gemini/, .codex/, .cursor/), shared (.agents/, dark-factory/, knowledge-vault/). Release domains (docs/, scripts/, patterns_library/) are not yet supported and will be rejected.",
           "items": {
             "type": "string",
-            "enum": [".claude/", ".gemini/", ".codex/", ".cursor/", ".agents/", "dark-factory/"],
+            "enum": [".claude/", ".gemini/", ".codex/", ".cursor/", ".agents/", "dark-factory/", "knowledge-vault/"],
             "description": "Sync domain directory (must be from the allowed domain list)."
           },
           "uniqueItems": true,

--- a/.harness-manifest.yml
+++ b/.harness-manifest.yml
@@ -159,6 +159,7 @@ sync:
     - ".cursor/"
     - ".agents/"
     - "dark-factory/"
+    - "knowledge-vault/"
 
   # Automatically apply substitutions from the identity/substitutions
   # sections to incoming upstream files during sync.

--- a/.harness-manifest.yml
+++ b/.harness-manifest.yml
@@ -149,7 +149,7 @@ sync:
   # Only include domains your project actually uses.
   # Allowed domains:
   #   Provider: .claude/, .gemini/, .codex/, .cursor/
-  #   Shared:   .agents/, dark-factory/
+  #   Shared:   .agents/, dark-factory/, knowledge-vault/
   # Release domains (docs/, scripts/, patterns_library/) deferred to future version.
   # Default: [".claude/"]
   sync_scope:

--- a/docs/HARNESS_MANIFEST_SCHEMA.md
+++ b/docs/HARNESS_MANIFEST_SCHEMA.md
@@ -9,7 +9,7 @@
 
 - **`sync_scope`**: Array of directories to sync from upstream (default: `[".claude/"]`)
 - **Root-relative paths**: All paths in `renames`, `protected`, `replaced` are now repo-root-relative in the schema
-- **Domain tiers**: Provider (`.claude/`, `.gemini/`, `.codex/`, `.cursor/`), Shared (`.agents/`, `dark-factory/`), Release (`docs/`, `scripts/` — deferred)
+- **Domain tiers**: Provider (`.claude/`, `.gemini/`, `.codex/`, `.cursor/`), Shared (`.agents/`, `dark-factory/`, `knowledge-vault/`), Release (`docs/`, `scripts/` — deferred)
 - **Backward compat**: v1.0 manifests work unchanged — paths without scope prefix are normalized by prepending `.claude/` during load
 
 ## Overview
@@ -302,6 +302,7 @@ sync:
     - ".cursor/"
     - ".agents/"
     - "dark-factory/"
+    - "knowledge-vault/"
   auto_substitute: true
   backup: true
   conflict_strategy: "prompt"
@@ -330,7 +331,7 @@ are synced; all others are skipped.
 | Tier | Domains | Description |
 |------|---------|-------------|
 | Provider | `.claude/`, `.gemini/`, `.codex/`, `.cursor/` | IDE-specific harness configs |
-| Shared | `.agents/`, `dark-factory/` | Cross-provider shared resources |
+| Shared | `.agents/`, `dark-factory/`, `knowledge-vault/` | Cross-provider shared resources |
 
 Release domains (`docs/`, `scripts/`, `patterns_library/`) are not yet supported and will
 be rejected if listed. These will be added in a future version with separate gating.

--- a/scripts/sync-claude-harness.sh
+++ b/scripts/sync-claude-harness.sh
@@ -53,7 +53,7 @@ UPSTREAM_PATH=".claude"  # Legacy default; overridden by SYNC_SCOPE when manifes
 
 # Multi-domain sync scope (v1.1+)
 # Allowed domains — hardcoded allowlist for v2.10.0
-ALLOWED_DOMAINS=(".claude" ".gemini" ".codex" ".cursor" ".agents" "dark-factory")
+ALLOWED_DOMAINS=(".claude" ".gemini" ".codex" ".cursor" ".agents" "dark-factory" "knowledge-vault")
 SYNC_SCOPE=()  # Populated by get_sync_scope() after manifest load
 
 # Colors

--- a/scripts/sync-claude-harness.sh
+++ b/scripts/sync-claude-harness.sh
@@ -126,16 +126,16 @@ get_sync_scope() {
         local in_scope=false
         while IFS= read -r line; do
             # Detect sync_scope: array start
-            if echo "$line" | grep -q '^\s*sync_scope:'; then
+            if echo "$line" | grep -q '^[[:space:]]*sync_scope:'; then
                 in_scope=true
                 continue
             fi
             # Stop at next non-array line (not starting with -)
             if [ "$in_scope" = true ]; then
-                if echo "$line" | grep -q '^\s*-'; then
+                if echo "$line" | grep -q '^[[:space:]]*-'; then
                     # Extract value: strip leading whitespace, dash, quotes, trailing /
                     local domain
-                    domain=$(echo "$line" | sed 's/^\s*-\s*//; s/^["'"'"']//; s/["'"'"']$//; s|/$||; s/\s*$//')
+                    domain=$(echo "$line" | sed 's/^[[:space:]]*-[[:space:]]*//; s/^["'"'"']//; s/["'"'"']$//; s|/$||; s/[[:space:]]*$//')
                     [ -z "$domain" ] && continue
                     # Validate against allowed domains
                     local valid=false
@@ -1493,7 +1493,14 @@ do_rollback() {
         ts_name=$(basename "$ts_dir")
         # Parse ISO timestamp to epoch for comparison
         local epoch
-        epoch=$(date -d "$ts_name" +%s 2>/dev/null || echo 0)
+        # GNU date understands -d; BSD/macOS date needs -j -f with an explicit
+        # input format. Try GNU first, then BSD, and only then give up. Without
+        # the BSD arm every epoch was 0 on macOS, so no backup ever ranked as
+        # latest and do_rollback reported "No backups available" with backups
+        # sitting on disk.
+        epoch=$(date -d "$ts_name" +%s 2>/dev/null \
+            || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$ts_name" +%s 2>/dev/null \
+            || echo 0)
         if [ "$epoch" -gt "$latest_epoch" ]; then
             latest_epoch=$epoch
             latest_timestamp="$ts_name"
@@ -1556,8 +1563,12 @@ do_diff() {
 
     local new=0 modified=0 deleted=0 excluded=0 unchanged=0 renamed=0 protected=0
 
-    # Track directory rename file counts for summary output
-    declare -A dir_rename_counts
+    # Track directory rename file counts for summary output.
+    # Parallel indexed arrays, not an associative array: `declare -A` requires
+    # bash 4, and macOS ships bash 3.2 where it aborts do_diff outright, so no
+    # patches were ever generated on a stock Mac.
+    local dir_rename_keys=()
+    local dir_rename_vals=()
 
     # Determine manifest version for path handling
     local manifest_ver=""
@@ -1637,7 +1648,20 @@ do_diff() {
                 fi
             done < <(get_directory_renames)
             if [ -n "$dir_key" ]; then
-                dir_rename_counts["$dir_key"]=$(( ${dir_rename_counts["$dir_key"]:-0} + 1 ))
+                local dr_i=0 dr_found=-1
+                while [ $dr_i -lt ${#dir_rename_keys[@]} ]; do
+                    if [ "${dir_rename_keys[$dr_i]}" = "$dir_key" ]; then
+                        dr_found=$dr_i
+                        break
+                    fi
+                    dr_i=$((dr_i + 1))
+                done
+                if [ $dr_found -ge 0 ]; then
+                    dir_rename_vals[$dr_found]=$(( ${dir_rename_vals[$dr_found]} + 1 ))
+                else
+                    dir_rename_keys+=("$dir_key")
+                    dir_rename_vals+=(1)
+                fi
             fi
         fi
 
@@ -1697,14 +1721,17 @@ do_diff() {
     done < <(find "$DOMAIN_DIR" -type f ! -path "$BACKUP_DIR/*" -print0 2>/dev/null)
 
     # Show directory rename summary lines for this domain
-    if [ ${#dir_rename_counts[@]} -gt 0 ]; then
+    if [ ${#dir_rename_keys[@]} -gt 0 ]; then
         echo ""
-        for dir_key in "${!dir_rename_counts[@]}"; do
+        local dr_j=0
+        while [ $dr_j -lt ${#dir_rename_keys[@]} ]; do
+            dir_key="${dir_rename_keys[$dr_j]}"
             local src_dir="${dir_key%%|*}"
             local dst_dir="${dir_key##*|}"
-            local count="${dir_rename_counts[$dir_key]}"
+            local count="${dir_rename_vals[$dr_j]}"
             echo -e "${CYAN}RENAMED${NC}  ${src_dir} -> ${dst_dir} ($count files)"
             renamed=$((renamed + count))
+            dr_j=$((dr_j + 1))
         done
     fi
 

--- a/tests/test-multi-domain-sync.sh
+++ b/tests/test-multi-domain-sync.sh
@@ -252,12 +252,20 @@ result=$(
     echo "${ALLOWED_DOMAINS[*]}"
 )
 
+# This is the ONLY test that reads ALLOWED_DOMAINS out of the shipped script rather than a
+# hardcoded stub, so it is the only regression guard on the production allowlist. Every domain
+# must be asserted here, and the count checked, or a domain could be dropped from the engine
+# while the rest of this suite still passes against its own local copies.
 assert_contains "$result" ".claude" "allowed: .claude"
 assert_contains "$result" ".gemini" "allowed: .gemini"
 assert_contains "$result" ".codex" "allowed: .codex"
 assert_contains "$result" ".cursor" "allowed: .cursor"
 assert_contains "$result" ".agents" "allowed: .agents"
 assert_contains "$result" "dark-factory" "allowed: dark-factory"
+assert_contains "$result" "knowledge-vault" "allowed: knowledge-vault"
+
+allowed_count=$(echo "$result" | tr ' ' '\n' | grep -c '.' | tr -d ' ')
+assert_equals "$allowed_count" "7" "engine declares exactly 7 allowed domains"
 
 # =============================================================================
 echo -e "\n${CYAN}=== Test 8: v1.1 protected-path enforcement outside .claude ===${NC}\n"

--- a/tests/test-multi-domain-sync.sh
+++ b/tests/test-multi-domain-sync.sh
@@ -603,7 +603,7 @@ result=$(
     generate_apply_order "$patches_version_dir" "test-v1" 2>/dev/null
 
     # Verify results
-    patch_count=$(find "$patches_version_dir" -name "*.patch" | wc -l)
+    patch_count=$(find "$patches_version_dir" -name "*.patch" | wc -l | tr -d " ")
     echo "PATCH_COUNT:$patch_count"
 
     if [ -f "$patches_version_dir/APPLY_ORDER.md" ]; then
@@ -617,8 +617,8 @@ result=$(
     fi
 
     # Check patches from first domain weren't wiped by second
-    claude_patches=$(find "$patches_version_dir" -name "*bsa*.patch" | wc -l)
-    gemini_patches=$(find "$patches_version_dir" -name "*skills*.patch" | wc -l)
+    claude_patches=$(find "$patches_version_dir" -name "*bsa*.patch" | wc -l | tr -d " ")
+    gemini_patches=$(find "$patches_version_dir" -name "*skills*.patch" | wc -l | tr -d " ")
     echo "CLAUDE_PATCHES:$claude_patches"
     echo "GEMINI_PATCHES:$gemini_patches"
 

--- a/tests/test-multi-domain-sync.sh
+++ b/tests/test-multi-domain-sync.sh
@@ -65,7 +65,18 @@ assert_not_contains() {
 make_sourceable() {
     local src="$1"
     local dst="$2"
-    sed -n '1,/^case "\${1:-}"/p' "$src" | head -n -3 > "$dst"
+    # Drop the trailing 3 lines of the extracted prefix. `head -n -3` is a GNU
+    # extension; BSD/macOS head rejects a negative count ("illegal line count"),
+    # which under `set -euo pipefail` aborted this entire suite before Test 1.
+    # Count first, then take an explicit positive head so both behave alike.
+    local extracted total
+    extracted=$(sed -n '1,/^case "\${1:-}"/p' "$src")
+    total=$(printf '%s\n' "$extracted" | wc -l | tr -d ' ')
+    if [ "$total" -gt 3 ]; then
+        printf '%s\n' "$extracted" | head -n "$((total - 3))" > "$dst"
+    else
+        : > "$dst"
+    fi
 }
 
 # =============================================================================

--- a/tests/test-multi-domain-sync.sh
+++ b/tests/test-multi-domain-sync.sh
@@ -91,7 +91,7 @@ result=$(
     PROJECT_ROOT="$REAL_PROJECT_ROOT"
     CLAUDE_DIR="$REAL_PROJECT_ROOT/.claude"
     MANIFEST_FILE="$REAL_PROJECT_ROOT/.harness-manifest.yml"
-    ALLOWED_DOMAINS=(".claude" ".gemini" ".codex" ".cursor" ".agents" "dark-factory")
+    ALLOWED_DOMAINS=(".claude" ".gemini" ".codex" ".cursor" ".agents" "dark-factory" "knowledge-vault")
     SYNC_SCOPE=()
     HAS_MANIFEST=true
     get_sync_scope
@@ -104,9 +104,10 @@ assert_contains "$result" ".codex" "sync_scope includes .codex"
 assert_contains "$result" ".cursor" "sync_scope includes .cursor"
 assert_contains "$result" ".agents" "sync_scope includes .agents"
 assert_contains "$result" "dark-factory" "sync_scope includes dark-factory"
+assert_contains "$result" "knowledge-vault" "sync_scope includes knowledge-vault"
 
-count=$(echo "$result" | tr ' ' '\n' | grep -c '.')
-assert_equals "$count" "6" "sync_scope has exactly 6 domains"
+count=$(echo "$result" | tr ' ' '\n' | grep -c '.' | tr -d ' ')
+assert_equals "$count" "7" "sync_scope has exactly 7 domains"
 
 # =============================================================================
 echo -e "\n${CYAN}=== Test 2: get_sync_scope defaults to .claude for v1.0 ===${NC}\n"
@@ -129,7 +130,7 @@ result=$(
     source "$SOURCEABLE"
     PROJECT_ROOT="$TMPDIR_T2"
     MANIFEST_FILE="$TMPDIR_T2/manifest.yml"
-    ALLOWED_DOMAINS=(".claude" ".gemini" ".codex" ".cursor" ".agents" "dark-factory")
+    ALLOWED_DOMAINS=(".claude" ".gemini" ".codex" ".cursor" ".agents" "dark-factory" "knowledge-vault")
     SYNC_SCOPE=()
     HAS_MANIFEST=true
     get_sync_scope
@@ -163,7 +164,7 @@ result=$(
     source "$SOURCEABLE"
     PROJECT_ROOT="$TMPDIR_T3"
     MANIFEST_FILE="$TMPDIR_T3/manifest.yml"
-    ALLOWED_DOMAINS=(".claude" ".gemini" ".codex" ".cursor" ".agents" "dark-factory")
+    ALLOWED_DOMAINS=(".claude" ".gemini" ".codex" ".cursor" ".agents" "dark-factory" "knowledge-vault")
     SYNC_SCOPE=()
     HAS_MANIFEST=true
     get_sync_scope 2>&1
@@ -187,7 +188,7 @@ result=$(
     MANIFEST_FILE="$TMPDIR_T4/.harness-manifest.yml"
     HAS_MANIFEST=false
     SYNC_SCOPE=(".claude")
-    ALLOWED_DOMAINS=(".claude" ".gemini" ".codex" ".cursor" ".agents" "dark-factory")
+    ALLOWED_DOMAINS=(".claude" ".gemini" ".codex" ".cursor" ".agents" "dark-factory" "knowledge-vault")
     # Simulate do_sync's manifest check
     if [ "$HAS_MANIFEST" != "true" ]; then
         echo "BLOCKED:manifest required"
@@ -292,7 +293,7 @@ result=$(
     MANIFEST_FILE="$TMPDIR_T8/.harness-manifest.yml"
     MANIFEST_JSON=""
     HAS_MANIFEST=false
-    ALLOWED_DOMAINS=(".claude" ".gemini" ".codex" ".cursor" ".agents" "dark-factory")
+    ALLOWED_DOMAINS=(".claude" ".gemini" ".codex" ".cursor" ".agents" "dark-factory" "knowledge-vault")
     load_manifest
     # Test: is .gemini/settings.json protected?
     if is_excluded ".gemini/settings.json" 2>/dev/null; then
@@ -452,7 +453,7 @@ result=$(
     MANIFEST_FILE="$TMPDIR_T12/.harness-manifest.yml"
     MANIFEST_JSON=""
     HAS_MANIFEST=false
-    ALLOWED_DOMAINS=(".claude" ".gemini" ".codex" ".cursor" ".agents" "dark-factory")
+    ALLOWED_DOMAINS=(".claude" ".gemini" ".codex" ".cursor" ".agents" "dark-factory" "knowledge-vault")
     SYNC_SCOPE=()
     TMP_DIR=$(mktemp -d)
     load_manifest
@@ -538,7 +539,7 @@ result=$(
     MANIFEST_FILE="$TMPDIR_T14/.harness-manifest.yml"
     MANIFEST_JSON=""
     HAS_MANIFEST=false
-    ALLOWED_DOMAINS=(".claude" ".gemini" ".codex" ".cursor" ".agents" "dark-factory")
+    ALLOWED_DOMAINS=(".claude" ".gemini" ".codex" ".cursor" ".agents" "dark-factory" "knowledge-vault")
     SYNC_SCOPE=()
     PATCHES_DIR="$TMPDIR_T14/.harness-patches"
     BACKUP_DIR="$TMPDIR_T14/.harness-backup"


### PR DESCRIPTION
## Summary

**Linear**: [SAW-60](https://linear.app/cheddarfox/issue/SAW-60)

> ⚠️ **Stacked on #56 (SAW-61).** Base is `SAW-61-posix-sync-scope-parsing`, not `dev`, because the sync-domain allowlist could not be verified locally until SAW-61 made the proving suite runnable. **Retarget to `dev` once #56 merges.**

The `knowledge-vault/` subsystem shipped in GH#55 but was absent from `sync_scope`, so **no downstream fork receives it on update**. GH#55's own PR body flagged the gap.

## Why it is not a one-line change

`sync_scope` is enforced by an allowlist. Adding only the manifest entry would be **silently dropped** at runtime (`Ignoring unknown sync domain`) and rejected by the schema. All coordinated sites updated:

| File | Change |
| --- | --- |
| `scripts/sync-claude-harness.sh:56` | `ALLOWED_DOMAINS` — the runtime enforcement |
| `.harness-manifest.schema.json` | `sync_scope.items.enum` + tier description |
| `.harness-manifest.yml` | the `sync_scope` entry itself |
| `docs/HARNESS_MANIFEST_SCHEMA.md` | domain-tier docs, 3 locations |
| `tests/test-multi-domain-sync.sh` | **7** hardcoded copies of the allowlist |

That the allowlist lives in 8 places is a DRY problem worth noting, though not one this PR sets out to fix.

## Design decision

`knowledge-vault/` joins the **Shared** tier beside `.agents/` and `dark-factory/` — the existing precedent for a shipped subsystem that is not a provider surface. Adding an enum value is backward-compatible, so **no `manifest_version` bump**.

## Testing — local, on macOS

```text
test-multi-domain-sync:  42/42 PASS, exit 0
  PASS  sync_scope includes knowledge-vault
  PASS  sync_scope has exactly 7 domains

engine end-to-end against the real manifest:
  SYNC_SCOPE = [.claude .gemini .codex .cursor .agents dark-factory knowledge-vault]
  count = 7

full sweep: 8 of 9 suites passing (fork-sync = missing fixture, pre-existing, see #56)
```

The Test 1 assertion legitimately moved from "exactly 6 domains" to 7, and a positive assertion for `knowledge-vault` was added so the new domain is proven accepted rather than merely not-rejected.

## Impact

Downstream forks will receive `knowledge-vault/` on their next sync, which is the point — the subsystem and the SAFe x AI-DLC methodology should reach adopters together.

## Checklist

- [x] All 5 enforcement sites updated, not just the manifest
- [x] Proven locally: the domain is accepted, not silently dropped
- [x] Full suite regression-swept
- [ ] Retarget to `dev` after #56 merges
- [ ] HITL merge