### PR TITLE
feat(agents): make model selection real, validated, and Fable-capable [SAW-62]

### DIFF
--- a/.claude/hooks/session-start-pattern-check.sh
+++ b/.claude/hooks/session-start-pattern-check.sh
@@ -26,9 +26,22 @@ fi
 
 echo ""
 echo "🤖 Agent System Ready"
-echo "   11 agents available in .claude/agents/"
-echo "   Tool restrictions: ✅ Configured"
-echo "   Model selection: ✅ Opus (planning), Sonnet (execution)"
+
+# Report what is actually on disk rather than asserting a taxonomy.
+# This banner previously printed "Model selection: ✅ Opus (planning), Sonnet
+# (execution)" as a verified fact. It was false — every agent declares opus —
+# and nothing here ever checked it. A green check for an unperformed check is
+# worse than no line at all, so these are counted, not claimed.
+AGENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../agents" 2>/dev/null && pwd)"
+if [ -n "$AGENT_DIR" ] && [ -d "$AGENT_DIR" ]; then
+  AGENT_COUNT=$(find "$AGENT_DIR" -maxdepth 1 -name '*.md' ! -name 'README.md' -type f | wc -l | tr -d ' ')
+  MODELS=$(awk 'FNR==1{n=0} /^---$/{n++; next} n==1 && /^model:/{sub(/^model:[[:space:]]*/,""); print}' \
+      "$AGENT_DIR"/*.md 2>/dev/null | sort -u | paste -sd, - )
+  echo "   ${AGENT_COUNT} agents available in .claude/agents/"
+  echo "   Models in use: ${MODELS:-inherit (none declared)}"
+else
+  echo "   Agent directory not found"
+fi
 echo ""
 
 exit 0

--- a/.claude/hooks/session-start-pattern-check.sh
+++ b/.claude/hooks/session-start-pattern-check.sh
@@ -35,8 +35,18 @@ echo "🤖 Agent System Ready"
 AGENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../agents" 2>/dev/null && pwd)"
 if [ -n "$AGENT_DIR" ] && [ -d "$AGENT_DIR" ]; then
   AGENT_COUNT=$(find "$AGENT_DIR" -maxdepth 1 -name '*.md' ! -name 'README.md' -type f | wc -l | tr -d ' ')
-  MODELS=$(awk 'FNR==1{n=0} /^---$/{n++; next} n==1 && /^model:/{sub(/^model:[[:space:]]*/,""); print}' \
-      "$AGENT_DIR"/*.md 2>/dev/null | sort -u | paste -sd, - )
+  # CR stripped per-line so CRLF checkouts still report real values instead of silently
+  # showing none; quotes and trailing space tolerated as valid YAML.
+  MODELS=$(awk '
+      FNR==1 { n=0 }
+      { sub(/\r$/, "") }
+      /^---$/ { n++; next }
+      n==1 && /^model:/ {
+          sub(/^model:[[:space:]]*/, "")
+          sub(/[[:space:]]+$/, "")
+          gsub(/^["'"'"']|["'"'"']$/, "")
+          print
+      }' "$AGENT_DIR"/*.md 2>/dev/null | sort -u | paste -sd, - )
   echo "   ${AGENT_COUNT} agents available in .claude/agents/"
   echo "   Models in use: ${MODELS:-inherit (none declared)}"
 else

--- a/docs/onboarding/AGENT-SETUP-GUIDE.md
+++ b/docs/onboarding/AGENT-SETUP-GUIDE.md
@@ -95,9 +95,14 @@ Expected output:
 
 🤖 Agent System Ready
    11 agents available in .claude/agents/
-   Tool restrictions: ✅ Configured
-   Model selection: ✅ Opus (planning), Sonnet (execution)
+   Models in use: opus
 ```
+
+The `Models in use:` line lists the distinct `model:` values actually declared across
+`.claude/agents/*.md`, so it tracks the files rather than asserting a taxonomy. If you change an
+agent's model it changes here on the next session start. See
+[Agent Configuration SOP](../sop/AGENT_CONFIGURATION_SOP.md#model-selection) for the valid values
+and how to evaluate a different model across the whole team.
 
 ---
 

--- a/docs/sop/AGENT_CONFIGURATION_SOP.md
+++ b/docs/sop/AGENT_CONFIGURATION_SOP.md
@@ -108,7 +108,6 @@ model: opus
 ```
 
 - **Why**: Needs Linear access for ticket analysis and spec creation
-- **Why Opus**: Complex planning and requirements decomposition
 
 ### System Architect
 
@@ -118,7 +117,6 @@ model: opus
 ```
 
 - **Why**: Pattern validation and architectural decisions
-- **Why Opus**: High-level architectural thinking required
 
 ### Execution Agents
 
@@ -130,7 +128,6 @@ model: opus
 ```
 
 - **Why**: Implementation only, no Linear/git access (RTE handles)
-- **Why Sonnet**: Fast, efficient implementation
 
 ### FE Developer
 
@@ -140,7 +137,6 @@ model: opus
 ```
 
 - **Why**: UI implementation only
-- **Why Sonnet**: Fast, efficient implementation
 
 ### Data Engineer
 
@@ -150,7 +146,6 @@ model: opus
 ```
 
 - **Why**: Schema changes and migrations
-- **Why Sonnet**: Structured implementation work
 
 ### Data Provisioning Engineer
 
@@ -160,7 +155,6 @@ model: opus
 ```
 
 - **Why**: ETL and data pipeline implementation
-- **Why Sonnet**: Structured implementation work
 
 ### Quality Agents
 
@@ -181,7 +175,6 @@ model: opus
 
 - **Why Read/Bash/Grep**: Test execution and validation (no code modification)
 - **Why Linear MCP**: Posts final evidence + verdict to Linear (system of record)
-- **Why Sonnet**: Efficient test validation
 - **Role (v1.4)**: Gate Owner with iteration authority - work does not proceed without QAS approval
 
 ### Security Engineer
@@ -192,7 +185,6 @@ model: opus
 ```
 
 - **Why**: Security audits and validation only
-- **Why Sonnet**: Focused security checks
 
 ### Documentation Agent
 
@@ -205,7 +197,6 @@ model: opus
 
 - **Why**: Documentation creation and editing, batch doc updates
 - **Why Grep/Glob**: Find files needing updates across large doc sets
-- **Why Sonnet**: Efficient documentation writing
 
 ### Coordination Agents
 
@@ -217,7 +208,6 @@ model: opus
 ```
 
 - **Why**: Orchestration, Linear/Confluence updates, no code modification
-- **Why Sonnet**: Efficient coordination and management
 
 ### RTE (Release Train Engineer) - PR Shepherd (v1.4)
 
@@ -227,7 +217,6 @@ model: opus
 ```
 
 - **Why Read/Bash/Grep**: Git/PR management via Bash (git commands, gh CLI)
-- **Why Sonnet**: Efficient release coordination
 - **Role (v1.4)**: PR Shepherd - creates PRs, monitors CI, but does NOT write product code or merge
 - **Boundaries**: {{AUTHOR_NAME}} (HITL) remains final merge authority. RTE shepherds PRs to "Ready for HITL Review"
 
@@ -235,22 +224,13 @@ model: opus
 
 ## Model Selection Criteria
 
-### When to Use Opus
+See [Model Selection](#model-selection) above for the valid values, the resolution order, and how to
+evaluate a candidate model across the whole team.
 
-- **Complex Planning**: BSA requirements decomposition
-- **Architectural Decisions**: System Architect pattern validation
-- **Strategic Thinking**: High-level design and tradeoff analysis
-
-**Cost**: Higher per token, but critical for planning accuracy
-
-### When to Use Sonnet
-
-- **Implementation**: All execution agents (BE, FE, DE, etc.)
-- **Testing**: QAS and Security Engineer
-- **Documentation**: Tech Writer
-- **Coordination**: TDM and RTE
-
-**Cost**: Lower per token, optimized for structured tasks
+This section previously prescribed an "Opus for planning, Sonnet for execution" split by role. That
+split was never implemented — every agent declares `model: opus` — so the guidance has been removed
+rather than restated. Choosing a per-role taxonomy is an open question to settle with evidence, not
+a rule this document can assert.
 
 ---
 
@@ -326,18 +306,13 @@ model: opus            # opus | sonnet | haiku | fable | inherit | claude-*
 
 ### Step 4: Select Model
 
-**Opus if**:
+Set `model:` to one of the values in [Model Selection](#model-selection). Every existing agent
+declares `model: opus`; match that unless you have evidence for something else, and record the
+evidence on the ticket.
 
-- Complex planning or architecture
-- Strategic decision-making
-- Pattern creation/validation
-
-**Sonnet if**:
-
-- Implementation work
-- Testing and validation
-- Documentation
-- Coordination
+Do not infer a role-to-model mapping from this document — there isn't one, deliberately. If you
+want to try a different model, run the team on it with `CLAUDE_CODE_SUBAGENT_MODEL` and compare
+before committing a per-role change.
 
 ### Step 5: Test Configuration
 
@@ -411,9 +386,9 @@ Before committing agent configuration changes:
 
 **Solution**:
 
-1. Verify `model` field in frontmatter
-2. Confirm Opus for planning, Sonnet for execution
-3. Test with corrected model
+1. Verify the `model` field in frontmatter
+2. Run `bash tests/test-agent-models.sh` — it names the agent and the offending value
+3. Correct the value to one listed in [Model Selection](#model-selection)
 
 ### Frontmatter Parse Error
 

--- a/docs/sop/AGENT_CONFIGURATION_SOP.md
+++ b/docs/sop/AGENT_CONFIGURATION_SOP.md
@@ -24,7 +24,7 @@ Every agent file in `.claude/agents/` must start with YAML frontmatter:
 name: agent-name
 description: Brief description of agent role
 tools: [Tool1, Tool2, Tool3]
-model: opus|sonnet
+model: opus            # opus | sonnet | haiku | fable | inherit | claude-*
 ---
 ```
 
@@ -35,13 +35,70 @@ model: opus|sonnet
 | `name`        | Unique agent identifier (kebab-case) | `be-developer`                           |
 | `description` | Brief role description               | `Backend Developer - API implementation` |
 | `tools`       | Array of allowed tools               | `[Read, Write, Edit, Bash]`              |
-| `model`       | AI model selection                   | `opus` or `sonnet`                       |
+| `model`       | AI model selection                   | see [Model Selection](#model-selection)  |
+
+---
+
+## Model Selection
+
+### Valid values
+
+Per the [Claude Code subagent documentation](https://code.claude.com/docs/en/sub-agents), the
+`model:` field in a subagent definition accepts:
+
+| Value | Meaning |
+| --- | --- |
+| `opus`, `sonnet`, `haiku`, `fable` | model aliases |
+| `claude-*` | a full model ID, e.g. `claude-opus-4-8` |
+| `inherit` | use the main conversation's model |
+| *(omitted)* | same as `inherit` |
+
+**Fable is selectable via the `fable` alias.** A full `claude-fable-5` ID is not documented for
+subagent frontmatter, so prefer the alias.
+
+### Resolution order
+
+Highest precedence first:
+
+1. `CLAUDE_CODE_SUBAGENT_MODEL` environment variable
+2. the per-invocation `model` parameter
+3. the agent definition's `model:` frontmatter
+4. the main conversation's model
+
+### Why a bad value is dangerous here
+
+Claude Code resolves an unusable model by **silently falling back to the inherited model** — the
+docs state this for org-excluded models and do not specify behaviour for a typo. There is also **no
+documented way to check which model a subagent actually ran on** afterwards.
+
+A misconfigured model therefore produces no error and cannot be detected at runtime. Validation has
+to happen at config time, which is why `tests/test-agent-models.sh` exists and why it is proven to
+fail on a deliberately broken value rather than only proven to pass.
+
+### Current state
+
+All 11 agents declare `model: opus`. Earlier revisions of this SOP described an "Opus for planning,
+Sonnet for execution" split; that taxonomy was **never implemented on disk** and has been removed
+rather than restated, because a documented contract that the files contradict is worse than none.
+
+### Evaluating a different model
+
+Do not adopt a per-role taxonomy on assertion. Run the work both ways and compare:
+
+```bash
+# Run the entire agent team on Fable for one session — no file edits, no commit
+CLAUDE_CODE_SUBAGENT_MODEL=fable claude
+```
+
+Because the env var outranks frontmatter, this exercises every agent on the candidate model. Compare
+the output against the same work on the current model, then change `model:` per role with the
+evidence recorded on the ticket.
 
 ---
 
 ## Tool Restrictions by Agent Role
 
-### Planning Agents (Opus Model)
+### Planning Agents
 
 ### BSA (Business Systems Analyst)
 
@@ -63,13 +120,13 @@ model: opus
 - **Why**: Pattern validation and architectural decisions
 - **Why Opus**: High-level architectural thinking required
 
-### Execution Agents (Sonnet Model)
+### Execution Agents
 
 ### BE Developer
 
 ```yaml
 tools: [Read, Write, Edit, Bash, Grep, Glob]
-model: sonnet
+model: opus
 ```
 
 - **Why**: Implementation only, no Linear/git access (RTE handles)
@@ -79,7 +136,7 @@ model: sonnet
 
 ```yaml
 tools: [Read, Write, Edit, Bash, Grep, Glob]
-model: sonnet
+model: opus
 ```
 
 - **Why**: UI implementation only
@@ -89,7 +146,7 @@ model: sonnet
 
 ```yaml
 tools: [Read, Write, Edit, Bash, Grep, Glob]
-model: sonnet
+model: opus
 ```
 
 - **Why**: Schema changes and migrations
@@ -99,13 +156,13 @@ model: sonnet
 
 ```yaml
 tools: [Read, Write, Edit, Bash, Grep, Glob]
-model: sonnet
+model: opus
 ```
 
 - **Why**: ETL and data pipeline implementation
 - **Why Sonnet**: Structured implementation work
 
-### Quality Agents (Sonnet Model)
+### Quality Agents
 
 ### QAS (Quality Assurance Specialist) - Gate Owner (v1.4)
 
@@ -119,7 +176,7 @@ tools:
     mcp__{{MCP_LINEAR_SERVER}}__update_issue,
     mcp__{{MCP_LINEAR_SERVER}}__list_comments,
   ]
-model: sonnet
+model: opus
 ```
 
 - **Why Read/Bash/Grep**: Test execution and validation (no code modification)
@@ -131,32 +188,32 @@ model: sonnet
 
 ```yaml
 tools: [Read, Bash, Grep]
-model: sonnet
+model: opus
 ```
 
 - **Why**: Security audits and validation only
 - **Why Sonnet**: Focused security checks
 
-### Documentation Agent (Sonnet Model)
+### Documentation Agent
 
 ### Tech Writer
 
 ```yaml
 tools: [Read, Write, Edit, Grep, Glob, Bash]
-model: sonnet
+model: opus
 ```
 
 - **Why**: Documentation creation and editing, batch doc updates
 - **Why Grep/Glob**: Find files needing updates across large doc sets
 - **Why Sonnet**: Efficient documentation writing
 
-### Coordination Agents (Sonnet Model)
+### Coordination Agents
 
 ### TDM (Technical Delivery Manager)
 
 ```yaml
 tools: [Read, Bash, mcp__{{MCP_LINEAR_SERVER}}__*, mcp__{{MCP_CONFLUENCE_SERVER}}__*]
-model: sonnet
+model: opus
 ```
 
 - **Why**: Orchestration, Linear/Confluence updates, no code modification
@@ -166,7 +223,7 @@ model: sonnet
 
 ```yaml
 tools: [Read, Bash, Grep]
-model: sonnet
+model: opus
 ```
 
 - **Why Read/Bash/Grep**: Git/PR management via Bash (git commands, gh CLI)
@@ -249,7 +306,7 @@ touch .claude/agents/new-agent.md
 name: new-agent
 description: Brief role description
 tools: [appropriate tools based on role]
-model: opus|sonnet
+model: opus            # opus | sonnet | haiku | fable | inherit | claude-*
 ---
 # Agent Name
 

--- a/tests/test-agent-models.sh
+++ b/tests/test-agent-models.sh
@@ -23,6 +23,10 @@
 # =============================================================================
 
 set -euo pipefail
+# An unmatched glob must expand to nothing, not to the literal pattern. Without this the
+# empty-directory guard below is unreachable: awk fails on the literal "*.md", and set -e
+# kills the script before the guard can report anything useful.
+shopt -s nullglob
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -40,12 +44,39 @@ pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
 fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
 
 # Returns 0 if the value is a documented-valid subagent model.
+# claude-?* not claude-*: the bare prefix "claude-" names no model.
 is_valid_model() {
     case "$1" in
         sonnet|opus|haiku|fable|inherit) return 0 ;;
-        claude-*) return 0 ;;
+        claude-?*) return 0 ;;
         *) return 1 ;;
     esac
+}
+
+# Extract the frontmatter `model:` value from an agent definition.
+#
+# Three things this has to survive, each of which silently broke an earlier version:
+#   - CRLF line endings. /^---$/ does not match "---\r", so the frontmatter fence is never
+#     recognised, no value is extracted, and a bogus model reads as "omitted" and PASSES.
+#     A validator that degrades to accept-everything is worse than none, and a forked repo
+#     with core.autocrlf=true produces exactly this.
+#   - A body line starting with "model:". The n==1 guard confines matching to frontmatter.
+#   - Quoted or trailing-padded values. `model: "opus"` is what a YAML-aware formatter writes,
+#     and a trailing space is invisible; both are valid and must not be reported as failures.
+# Note: CR is stripped inside awk rather than by piping through `tr`. With a pipe, awk's
+# early `exit` closes it while tr is still writing a large agent file; tr takes SIGPIPE,
+# and under `set -o pipefail` that fails the whole script. Single process, no pipe, no race.
+extract_model() {
+    awk '
+        { sub(/\r$/, "") }
+        /^---$/ { n++; next }
+        n == 1 && /^model:/ {
+            sub(/^model:[[:space:]]*/, "")
+            sub(/[[:space:]]+$/, "")
+            gsub(/^["'"'"']|["'"'"']$/, "")
+            print
+            exit
+        }' "$1"
 }
 
 echo -e "\n${CYAN}=== Test 1: every agent declares a valid model ===${NC}\n"
@@ -57,7 +88,7 @@ for f in "$AGENTS_DIR"/*.md; do
     agent_count=$((agent_count + 1))
 
     # Read model: from the frontmatter block only (first --- ... --- section).
-    model=$(awk '/^---$/{n++; next} n==1 && /^model:/{sub(/^model:[[:space:]]*/,""); print; exit}' "$f")
+    model=$(extract_model "$f")
 
     if [ -z "$model" ]; then
         # Omitted is legal and means inherit.
@@ -104,13 +135,46 @@ inherited=0
 for f in "$AGENTS_DIR"/*.md; do
     name=$(basename "$f" .md)
     [ "$name" = "README" ] && continue
-    model=$(awk '/^---$/{n++; next} n==1 && /^model:/{sub(/^model:[[:space:]]*/,""); print; exit}' "$f")
+    model=$(extract_model "$f")
     if [ -z "$model" ] || [ "$model" = "inherit" ]; then
         echo "    note: $name inherits the session model"
         inherited=$((inherited + 1))
     fi
 done
 pass "$inherited of $agent_count agents inherit the session model (informational)"
+
+echo -e "\n${CYAN}=== Test 4: frontmatter parsing survives real-world formatting ===${NC}\n"
+# Each case below silently broke an earlier revision of this script. They are pinned here
+# because every one of them fails in the dangerous direction — reporting a bad config as fine.
+
+T=$(mktemp -d)
+trap 'rm -rf "$T"' EXIT
+
+# Valid YAML that a formatter or editor will produce. Must be ACCEPTED.
+printf -- '---\nname: q\nmodel: "opus"\ndescription: x\n---\nbody\n'   > "$T/quoted.md"
+printf -- '---\nname: t\nmodel: opus   \ndescription: x\n---\nbody\n'  > "$T/trailing.md"
+printf -- "---\nname: s\nmodel: 'fable'\ndescription: x\n---\nbody\n" > "$T/single.md"
+for f in quoted trailing single; do
+    got=$(extract_model "$T/$f.md")
+    if is_valid_model "$got"; then pass "$f: parsed '$got' and accepted"
+    else fail "$f: parsed '$got' and REJECTED it — valid YAML must not fail"; fi
+done
+
+# CRLF. Must still extract, so a bad value is still caught rather than read as "omitted".
+printf -- '---\r\nname: c\r\nmodel: gpt-5-bogus\r\ndescription: x\r\n---\r\nbody\r\n' > "$T/crlf.md"
+got=$(extract_model "$T/crlf.md")
+if [ "$got" = "gpt-5-bogus" ]; then pass "crlf: extracted '$got' (bad value still visible)"
+else fail "crlf: extracted '$got' — CRLF hides the value and a bad model would PASS"; fi
+
+# A body line starting with model: must not be mistaken for frontmatter.
+printf -- '---\nname: b\nmodel: opus\ndescription: x\n---\nmodel: bogus-in-body\n' > "$T/body.md"
+got=$(extract_model "$T/body.md")
+if [ "$got" = "opus" ]; then pass "body: read frontmatter '$got', ignored body line"
+else fail "body: read '$got' — body content leaked into the frontmatter parse"; fi
+
+# The bare prefix names no model.
+if is_valid_model "claude-"; then fail "'claude-' wrongly accepted — it names no model"
+else pass "rejects bare 'claude-'"; fi
 
 echo -e "\n${CYAN}=== Test Results ===${NC}\n"
 echo -e "  Total:  $((PASS + FAIL))"

--- a/tests/test-agent-models.sh
+++ b/tests/test-agent-models.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Agent Model Configuration Tests (SAW-62)
+# =============================================================================
+# Validates the `model:` field of every Claude Code subagent definition.
+#
+# WHY THIS TEST EXISTS
+# Claude Code resolves an unusable subagent model by SILENTLY falling back to
+# the inherited model. The docs state this for org-excluded models ("skips a
+# value that resolves to an excluded model and runs the subagent on the
+# inherited model instead") and do not document behaviour for a plain typo.
+# There is also no documented way to check which model a subagent actually ran
+# on afterwards.
+#
+# So a misconfigured model produces no error and cannot be detected at runtime.
+# Validation has to happen at config time, which is what this suite does.
+#
+# Valid values per code.claude.com/docs/en/sub-agents.md:
+#   aliases: sonnet | opus | haiku | fable
+#   full ids: anything matching claude-*
+#   inherit: use the main conversation's model
+#   omitted: defaults to inherit
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+AGENTS_DIR="$PROJECT_ROOT/.claude/agents"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+# Returns 0 if the value is a documented-valid subagent model.
+is_valid_model() {
+    case "$1" in
+        sonnet|opus|haiku|fable|inherit) return 0 ;;
+        claude-*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+echo -e "\n${CYAN}=== Test 1: every agent declares a valid model ===${NC}\n"
+
+agent_count=0
+for f in "$AGENTS_DIR"/*.md; do
+    name=$(basename "$f" .md)
+    [ "$name" = "README" ] && continue
+    agent_count=$((agent_count + 1))
+
+    # Read model: from the frontmatter block only (first --- ... --- section).
+    model=$(awk '/^---$/{n++; next} n==1 && /^model:/{sub(/^model:[[:space:]]*/,""); print; exit}' "$f")
+
+    if [ -z "$model" ]; then
+        # Omitted is legal and means inherit.
+        pass "$name: model omitted (defaults to inherit)"
+    elif is_valid_model "$model"; then
+        pass "$name: model '$model' is valid"
+    else
+        fail "$name: model '$model' is NOT a documented value (expected sonnet|opus|haiku|fable|inherit|claude-*)"
+    fi
+done
+
+echo ""
+if [ "$agent_count" -gt 0 ]; then
+    pass "found $agent_count agent definitions to check"
+else
+    fail "no agent definitions found under .claude/agents/ — the test would vacuously pass"
+fi
+
+echo -e "\n${CYAN}=== Test 2: the validator actually rejects a bad value ===${NC}\n"
+# A gate that only ever passes proves nothing. Prove the negative case.
+
+for bad in "opus-4" "gpt-5.4" "Opus" "sonet" ""; do
+    label="${bad:-<empty>}"
+    if is_valid_model "$bad"; then
+        fail "is_valid_model wrongly ACCEPTED '$label'"
+    else
+        pass "rejects '$label'"
+    fi
+done
+
+for good in "opus" "sonnet" "haiku" "fable" "inherit" "claude-opus-4-8" "claude-sonnet-5"; do
+    if is_valid_model "$good"; then
+        pass "accepts '$good'"
+    else
+        fail "is_valid_model wrongly REJECTED '$good'"
+    fi
+done
+
+echo -e "\n${CYAN}=== Test 3: no agent silently inherits by accident ===${NC}\n"
+# Inheriting is legal, but it should be a decision. Flag it as informational so
+# a reviewer sees it rather than discovering it at runtime, where it is invisible.
+
+inherited=0
+for f in "$AGENTS_DIR"/*.md; do
+    name=$(basename "$f" .md)
+    [ "$name" = "README" ] && continue
+    model=$(awk '/^---$/{n++; next} n==1 && /^model:/{sub(/^model:[[:space:]]*/,""); print; exit}' "$f")
+    if [ -z "$model" ] || [ "$model" = "inherit" ]; then
+        echo "    note: $name inherits the session model"
+        inherited=$((inherited + 1))
+    fi
+done
+pass "$inherited of $agent_count agents inherit the session model (informational)"
+
+echo -e "\n${CYAN}=== Test Results ===${NC}\n"
+echo -e "  Total:  $((PASS + FAIL))"
+echo -e "  ${GREEN}Passed: ${PASS}${NC}"
+echo -e "  ${RED}Failed: ${FAIL}${NC}"
+echo ""
+
+if [ "$FAIL" -gt 0 ]; then
+    echo -e "${RED}AGENT MODEL TESTS FAILED${NC}"
+    exit 1
+fi
+echo -e "${GREEN}ALL AGENT MODEL TESTS PASSED${NC}"
+exit 0


### PR DESCRIPTION
## Summary

**Linear**: [SAW-62](https://linear.app/cheddarfox/issue/SAW-62)

The harness had a per-agent model lever that was **undifferentiated**, and three documents asserting a taxonomy the files contradict.

Verified on disk: **all 11 agents declare `model: opus`**. No routing logic exists anywhere. Meanwhile:

| Site | Claim | Reality |
| --- | --- | --- |
| `AGENT_CONFIGURATION_SOP.md` | `model: sonnet` in **9 places** + 5 section headers | all agents are `opus` |
| `AGENT-SETUP-GUIDE.md:99` | `Model selection: ✅ Opus (planning), Sonnet (execution)` | false |
| `session-start-pattern-check.sh:31` | same string, printed as a **green checkmark** | the hook never checked anything |

The SOP was the source; the guide and hook echoed it. Independently rediscovered by the SAW-53 vault build as DOC DRIFT.

## Fable 5 is selectable today

Per [the subagent docs](https://code.claude.com/docs/en/sub-agents), `model:` accepts the aliases **`opus`, `sonnet`, `haiku`, `fable`**, any `claude-*` full ID, or `inherit` (the default when omitted). Use the `fable` **alias** — a full `claude-fable-5` ID is not documented for subagent frontmatter.

Resolution order: `CLAUDE_CODE_SUBAGENT_MODEL` env var → per-invocation `model` param → frontmatter → session model.

## Why validation is mandatory, not nice-to-have

**Claude Code resolves an unusable model by silently falling back to the inherited model.** The docs state this for org-excluded models and do not specify behaviour for a typo. There is also **no documented way to check which model a subagent actually ran on** afterwards.

A misconfigured agent therefore produces **no error and cannot be detected at runtime**. Validation has to happen at config time. Same failure class as `epoch=0` in `do_rollback`: a setting that looks applied and isn't.

## Changes

- **`tests/test-agent-models.sh`** — validates every agent's declared model against the documented set
- **`session-start-pattern-check.sh`** — counts agents and reports the distinct models actually on disk, instead of asserting a taxonomy
- **`AGENT_CONFIGURATION_SOP.md`** — stale examples removed; new Model Selection section with valid values, resolution order, the silent-fallback risk, and the evaluation recipe
- **`AGENT-SETUP-GUIDE.md`** — expected hook output corrected to reality

## Testing — the gate is proven, not assumed

```text
tests/test-agent-models.sh -> 25/25 PASS, exit 0

deliberate break: inject `model: opus-4-8` into bsa.md
  (exactly the typo someone makes reaching for claude-opus-4-8,
   which Claude Code would silently accept)
  -> exit 1, FAIL, names the agent and the bad value
restore -> exit 0

hook tracks reality:
  flip tech-writer to fable -> "Models in use: fable,opus"
  restore                   -> "Models in use: opus"

no regression: test-manifest-loader, test-preflight still PASS
```

A gate that only ever passes proves nothing, so the negative case is demonstrated rather than claimed.

## Deliberately NOT done

**Assigning Fable to specific roles.** No evidence exists in this repo for which roles suit which model, and inventing a "Fable for planning" taxonomy would recreate the exact defect this PR removes. The SOP documents the experiment instead:

```bash
CLAUDE_CODE_SUBAGENT_MODEL=fable claude   # whole team, one session, no edits
```

## Known, pre-existing, not introduced here

`AGENT-SETUP-GUIDE.md` carries 2 MD034 bare-URL lint errors, identical on `origin/dev`. Left alone to keep this diff focused.

## Checklist

- [x] Rebased on `dev`, linear history
- [x] Gate proven to FAIL on a bad value, not just to pass
- [x] All three false-claim sites corrected
- [x] Doc citations included for every mechanical claim
- [ ] HITL merge